### PR TITLE
Inject a repartition layer for inner merges

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -417,7 +417,12 @@ class Expr:
 
             if changed_dependency:
                 expr = type(expr)(*new_operands)
-                changed = True
+                if isinstance(expr, Projection):
+                    # We might introduce stacked Projections (merge for example).
+                    # So get rid of them here again
+                    expr_simplify_down = expr._simplify_down()
+                    if expr_simplify_down is not None:
+                        expr = expr_simplify_down
                 if update_root:
                     root = expr
                 continue

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2298,8 +2298,9 @@ def optimize_blockwise_fusion(expr):
                     dependents[next._name] = set()
                     expr_mapping[next._name] = next
 
+            next_deps = [dep._name for dep in next.dependencies()]
             for operand in next.operands:
-                if isinstance(operand, Expr):
+                if isinstance(operand, Expr) and operand._name in next_deps:
                     stack.append(operand)
                     if isinstance(operand, Blockwise):
                         if next._name in dependencies:

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -27,7 +27,7 @@ _HASH_COLUMN_NAME = "__hash_partition"
 
 
 def _partition_reducer(x):
-    return max(x // 3, 1)
+    return max(x // 2, 1)
 
 
 class Merge(Expr):

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -157,13 +157,11 @@ class Merge(Expr):
             and get_default_shuffle_method() == "p2p"
         ):
             left = AssignPartitioningIndex(
-                left, shuffle_left_on, _HASH_COLUMN_NAME, self.npartitions
+                left, shuffle_left_on, _HASH_COLUMN_NAME, lambda x: x, right
             )
             right = AssignPartitioningIndex(
-                right, shuffle_right_on, _HASH_COLUMN_NAME, self.npartitions
+                right, shuffle_right_on, _HASH_COLUMN_NAME, lambda x: x, left
             )
-            left = Repartition(left, lambda x: x // 2)
-            right = Repartition(right, lambda x: x // 2)
 
             return HashJoinP2P(
                 left,

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -167,8 +167,8 @@ class Merge(Expr):
             or shuffle_backend is None
             and get_default_shuffle_method() == "p2p"
         ):
-            left = Repartition(left, lambda x: x // 3)
-            right = Repartition(right, lambda x: x // 3)
+            left = Repartition(left, lambda x: max(x // 3, 1))
+            right = Repartition(right, lambda x: max(x // 3, 1))
 
             return HashJoinP2P(
                 left,

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -423,6 +423,7 @@ def create_assign_index_merge_transfer():
         else:
             index = partitioning_index(index, npartitions)
         df[name] = index
+        meta[name] = 0
         return merge_transfer(df, id, input_partition, npartitions, meta, parts_out)
 
     return assign_index_merge_transfer

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -26,6 +26,10 @@ from dask_expr._util import _convert_to_list
 _HASH_COLUMN_NAME = "__hash_partition"
 
 
+def _partition_reducer(x):
+    return max(x // 3, 1)
+
+
 class Merge(Expr):
     """Merge / join two dataframes
 
@@ -167,8 +171,8 @@ class Merge(Expr):
             or shuffle_backend is None
             and get_default_shuffle_method() == "p2p"
         ):
-            left = Repartition(left, lambda x: max(x // 3, 1))
-            right = Repartition(right, lambda x: max(x // 3, 1))
+            left = Repartition(left, _partition_reducer)
+            right = Repartition(right, _partition_reducer)
 
             return HashJoinP2P(
                 left,
@@ -286,23 +290,24 @@ class Merge(Expr):
             columns_right,
         )
 
+    @staticmethod
+    def _flatten_columns(expr, columns, side):
+        if len(columns) == 0:
+            return getattr(expr, side).columns
+        else:
+            return list(set(flatten(columns)))
+
     def _combine_similar(self, root: Expr):
         # Push projections back up to avoid performing the same merge multiple times
-
-        def _flatten_columns(columns, side=None):
-            if len(columns) == 0 and side is not None:
-                return getattr(self, side).columns
-            else:
-                return list(set(flatten(columns)))
 
         left, columns_left = self._remove_operations(
             self.left, self._remove_ops, self._skip_ops
         )
-        columns_left = _flatten_columns(columns_left, "left")
+        columns_left = self._flatten_columns(self, columns_left, "left")
         right, columns_right = self._remove_operations(
             self.right, self._remove_ops, self._skip_ops
         )
-        columns_right = _flatten_columns(columns_right, "right")
+        columns_right = self._flatten_columns(self, columns_right, "right")
 
         if left._name == self.left._name and right._name == self.right._name:
             # There aren't any ops we can remove, so bail
@@ -324,22 +329,22 @@ class Merge(Expr):
 
             validation = self._validate_same_operations(common_right, op, "left")
             if validation[0]:
-                left_sub = _flatten_columns(validation[1])
+                left_sub = self._flatten_columns(op, validation[1], side="left")
                 columns = self.right.columns.copy()
                 columns += [col for col in self.left.columns if col not in columns]
                 break
 
             validation = self._validate_same_operations(common_left, op, "right")
             if validation[0]:
-                right_sub = _flatten_columns(validation[2])
+                right_sub = self._flatten_columns(op, validation[2], side="right")
                 columns = self.left.columns.copy()
                 columns += [col for col in self.right.columns if col not in columns]
                 break
 
             validation = self._validate_same_operations(common_both, op)
             if validation[0]:
-                left_sub = _flatten_columns(validation[1])
-                right_sub = _flatten_columns(validation[2])
+                left_sub = self._flatten_columns(op, validation[1], side="left")
+                right_sub = self._flatten_columns(op, validation[2], side="right")
                 columns = columns_left.copy()
                 columns += [col for col in columns_right if col not in columns_left]
                 break

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -170,8 +170,9 @@ class Merge(Expr):
             or shuffle_backend is None
             and get_default_shuffle_method() == "p2p"
         ):
-            left = Repartition(left, _partition_reducer)
-            right = Repartition(right, _partition_reducer)
+            if self.how == "inner":
+                left = Repartition(left, _partition_reducer)
+                right = Repartition(right, _partition_reducer)
 
             return HashJoinP2P(
                 left,

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -162,6 +162,9 @@ class Merge(Expr):
             right = AssignPartitioningIndex(
                 right, shuffle_right_on, _HASH_COLUMN_NAME, self.npartitions
             )
+            left = Repartition(left, lambda x: x // 2)
+            right = Repartition(right, lambda x: x // 2)
+
             return HashJoinP2P(
                 left,
                 right,

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -361,7 +361,7 @@ class HashJoinP2P(Merge, PartitionsFiltered):
             dsk[(name_right, i)] = (
                 func,
                 (self.right._name, i),
-                self.shuffle_left_on,
+                self.shuffle_right_on,
                 _HASH_COLUMN_NAME,
                 self.npartitions,
                 self.right._name,

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -167,8 +167,8 @@ class Merge(Expr):
             or shuffle_backend is None
             and get_default_shuffle_method() == "p2p"
         ):
-            # left = Repartition(left, lambda x: x // 2)
-            # right = Repartition(right, lambda x: x // 2)
+            left = Repartition(left, lambda x: x // 3)
+            right = Repartition(right, lambda x: x // 3)
 
             return HashJoinP2P(
                 left,

--- a/dask_expr/_repartition.py
+++ b/dask_expr/_repartition.py
@@ -135,7 +135,7 @@ class RepartitionToFewer(Repartition):
     def _partitions_boundaries(self):
         npartitions = self.new_partitions
         npartitions_input = self.frame.npartitions
-        assert npartitions_input > npartitions
+        assert npartitions_input >= npartitions
 
         npartitions_ratio = npartitions_input / npartitions
         new_partitions_boundaries = [

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -2,7 +2,6 @@ import functools
 import math
 import operator
 import uuid
-from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -606,26 +605,7 @@ class AssignPartitioningIndex(Blockwise):
         Number of partitions after repartitioning is finished.
     """
 
-    _parameters = [
-        "frame",
-        "partitioning_index",
-        "index_name",
-        "npartitions_out",
-        "other",
-    ]
-    _defaults = {"other": None}
-
-    def dependencies(self):
-        return [self.frame]
-
-    @functools.cached_property
-    def _args(self) -> list:
-        ops = self.operands.copy()
-        npart = ops[-2]
-        if isinstance(npart, Callable):
-            ops[-2] = npart(max(self.frame.npartitions, self.other.npartitions))
-        ops.pop(-1)
-        return ops
+    _parameters = ["frame", "partitioning_index", "index_name", "npartitions_out"]
 
     @staticmethod
     def operation(df, index, name: str, npartitions: int):

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -137,6 +137,9 @@ class FusedIO(BlockwiseIO):
     def npartitions(self):
         return len(self._fusion_buckets)
 
+    def _broadcast_dep(self, dep: Expr):
+        return dep.npartitions == 1
+
     def _divisions(self):
         divisions = self.operand("expr")._divisions()
         new_divisions = [divisions[b[0]] for b in self._fusion_buckets]


### PR DESCRIPTION
Restricting this to inner joins at the moment, this seems to be faster even though we create a lot of network traffic, sits on top of #334 

The whole logic needs a bit more thought I think