### PR TITLE
Adjust class hierarchy for overlapping stuff

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2489,7 +2489,7 @@ def non_blockwise_ancestors(expr):
         e = stack.pop()
         if isinstance(e, IO):
             yield e
-        elif isinstance(e, Blockwise):
+        elif isinstance(e, BlockwiseOverlapping):
             dependencies = e.dependencies()
             stack.extend([expr for expr in dependencies if not is_broadcastable(expr)])
         else:


### PR DESCRIPTION
Not sure what to think of this (looking into cumulative stuff, so this came up again)

MapOverlap behaves like Blockwise stuff if we look at the expression when trying to make decisions about alignment and things like this but Blockwise obviously isn't quite correct, since we need neighbouring partitions

Injecting another layer solves this kind of, but I don't want to end up in inheritance hell...