### PR TITLE
Revert enabling pandas cow

### DIFF
--- a/dask_expr/__init__.py
+++ b/dask_expr/__init__.py
@@ -16,8 +16,3 @@ from dask_expr.io.records import to_records
 from dask_expr.io.sql import read_sql, read_sql_query, read_sql_table, to_sql
 
 __version__ = _version.get_versions()["version"]
-
-import pandas as pd
-
-pd.set_option("mode.copy_on_write", True)
-del pd


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/10996

In the interest of compatibility we should not set this toggle.

We strongly recommend to users to enable this themselves but setting it for them on import is causing more fallout than we anticipated.