### PR TITLE
Remove keys()

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -2518,9 +2518,6 @@ class DataFrame(FrameBase):
             "`len(df.index) == 0` or `len(df.columns) == 0`"
         )
 
-    def keys(self):
-        return self.columns
-
     @derived_from(pd.DataFrame)
     def items(self):
         for i, name in enumerate(self.columns):
@@ -3923,9 +3920,6 @@ class Series(FrameBase):
     def nbytes(self):
         """Number of bytes"""
         return new_collection(self.expr.nbytes)
-
-    def keys(self):
-        return self.index
 
     def __array_ufunc__(self, numpy_ufunc, method, *inputs, **kwargs):
         out = kwargs.get("out", ())

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -2362,11 +2362,6 @@ def test_scalar_to_series():
     assert_eq(ss2, pd.Series([1], index=["xxx"]))
 
 
-def test_keys(df, pdf):
-    assert_eq(df.keys(), pdf.keys())  # Alias for DataFrame.columns
-    assert_eq(df.x.keys(), pdf.x.keys())  # Alias for Series.index
-
-
 @pytest.mark.parametrize("data_freq, divs1", [("B", False), ("D", True), ("h", True)])
 def test_shift_with_freq_datetime(pdf, data_freq, divs1):
     pdf.index = pd.date_range(start="2020-01-01", periods=len(pdf), freq=data_freq)


### PR DESCRIPTION
This screws with pandas internals and isn't part of dask/dask either