### PR TITLE
Support ``prefix`` argument in  ``from_delayed``

### DIFF
--- a/dask_expr/io/tests/test_delayed.py
+++ b/dask_expr/io/tests/test_delayed.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from dask import delayed
 
 from dask_expr import from_delayed
@@ -7,19 +8,24 @@ from dask_expr.tests._util import _backend_library, assert_eq
 pd = _backend_library()
 
 
-def test_from_delayed():
+@pytest.mark.parametrize("prefix", [None, "foo"])
+def test_from_delayed(prefix):
     pdf = pd.DataFrame(
         data=np.random.normal(size=(10, 4)), columns=["a", "b", "c", "d"]
     )
     parts = [pdf.iloc[:1], pdf.iloc[1:3], pdf.iloc[3:6], pdf.iloc[6:10]]
     dfs = [delayed(parts.__getitem__)(i) for i in range(4)]
 
-    df = from_delayed(dfs, meta=pdf.head(0), divisions=None)
+    df = from_delayed(dfs, meta=pdf.head(0), divisions=None, prefix=prefix)
     assert_eq(df, pdf)
+    if prefix:
+        assert df._name.startswith(prefix)
 
     divisions = tuple([p.index[0] for p in parts] + [parts[-1].index[-1]])
-    df = from_delayed(dfs, meta=pdf.head(0), divisions=divisions)
+    df = from_delayed(dfs, meta=pdf.head(0), divisions=divisions, prefix=prefix)
     assert_eq(df, pdf)
+    if prefix:
+        assert df._name.startswith(prefix)
 
 
 def test_from_delayed_dask():


### PR DESCRIPTION
Adds support for the `prefix` argument in `from_delayed`. This kwarg is advertised in the docstring, and is sometimes useful.