### PR TITLE
Ensure drop matches column names exactly

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1725,9 +1725,10 @@ class Drop(Elemwise):
     operation = staticmethod(drop_by_shallow_copy)
 
     def _simplify_down(self):
-        columns = [
-            col for col in self.frame.columns if col not in self.operand("columns")
-        ]
+        col_op = self.operand("columns")
+        if not isinstance(col_op, list):
+            col_op = [col_op]
+        columns = [col for col in self.frame.columns if col not in col_op]
         return Projection(self.frame, columns)
 
 

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -10,6 +10,7 @@ from operator import add
 import dask
 import dask.array as da
 import numpy as np
+import pandas as pd
 import pytest
 from dask.dataframe._compat import PANDAS_GE_210, PANDAS_GE_220
 from dask.dataframe.utils import UNKNOWN_CATEGORIES
@@ -2533,3 +2534,12 @@ def test_warn_annotations():
     # Don't warn a second time
     with dask.annotate(retries=3):
         from_pandas(pd.DataFrame({"a": [1, 2, 3]}), npartitions=2)
+
+
+def test_drop_columns_with_common_prefix():
+    ddf = from_pandas(
+        pd.DataFrame({"prefix": [1, 2, 3], "prefix_foo": [4, 5, 6]}), npartitions=1
+    )
+
+    ddf = ddf.drop("prefix_foo", axis=1)
+    assert "prefix" in ddf.optimize().columns


### PR DESCRIPTION
This makes me think that the core `Expr` might want to support something like argument normalization. Not pushing for this but if more cases like this pop up, that might help.