### PR TITLE
Ensure that repr doesn't raise if an operand is a pandas object

### DIFF
--- a/dask_expr/_concat.py
+++ b/dask_expr/_concat.py
@@ -45,11 +45,7 @@ class Concat(Expr):
             "frames="
             + str(self.dependencies())
             + ", "
-            + ", ".join(
-                str(param) + "=" + str(operand)
-                for param, operand in zip(self._parameters, self.operands)
-                if operand is not self._defaults.get(param)
-            )
+            + ", ".join(self._operands_for_repr())
         )
         return f"{type(self).__name__}({s})"
 

--- a/dask_expr/_concat.py
+++ b/dask_expr/_concat.py
@@ -48,7 +48,7 @@ class Concat(Expr):
             + ", ".join(
                 str(param) + "=" + str(operand)
                 for param, operand in zip(self._parameters, self.operands)
-                if operand != self._defaults.get(param)
+                if operand is not self._defaults.get(param)
             )
         )
         return f"{type(self).__name__}({s})"
@@ -249,9 +249,11 @@ class Concat(Expr):
                 return
 
             frames = [
-                frame[cols]
-                if sorted(cols) != sorted(get_columns_or_name(frame))
-                else frame
+                (
+                    frame[cols]
+                    if sorted(cols) != sorted(get_columns_or_name(frame))
+                    else frame
+                )
                 for frame, cols in zip(self._frames, columns_frame)
                 if len(cols) > 0
             ]

--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -68,11 +68,11 @@ class Expr:
         return None
 
     def __str__(self):
-        s = ", ".join(
-            str(param) + "=" + str(operand)
-            for param, operand in zip(self._parameters, self.operands)
-            if isinstance(operand, Expr) or operand != self._defaults.get(param)
-        )
+        to_include = []
+        for param, operand in zip(self._parameters, self.operands):
+            if isinstance(operand, Expr) or operand is not self._defaults.get(param):
+                to_include.append(f"{param!r}={operand!r}")
+        s = ", ".join(to_include)
         return f"{type(self).__name__}({s})"
 
     def __repr__(self):

--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -67,12 +67,18 @@ class Expr:
     def _tune_up(self, parent):
         return None
 
-    def __str__(self):
+    def _operands_for_repr(self):
         to_include = []
         for param, operand in zip(self._parameters, self.operands):
-            if isinstance(operand, Expr) or operand is not self._defaults.get(param):
-                to_include.append(f"{param!r}={operand!r}")
-        s = ", ".join(to_include)
+            if isinstance(operand, Expr) or (
+                not isinstance(operand, (pd.Series, pd.DataFrame))
+                and operand != self._defaults.get(param)
+            ):
+                to_include.append(f"{param}={operand!r}")
+        return to_include
+
+    def __str__(self):
+        s = ", ".join(self._operands_for_repr())
         return f"{type(self).__name__}({s})"
 
     def __repr__(self):

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -766,7 +766,9 @@ class Reduction(ApplyConcatApply):
     def __str__(self):
         params = {param: self.operand(param) for param in self._parameters[1:]}
         s = ", ".join(
-            k + "=" + repr(v) for k, v in params.items() if v != self._defaults.get(k)
+            k + "=" + repr(v)
+            for k, v in params.items()
+            if v is not self._defaults.get(k)
         )
         base = str(self.frame)
         if " " in base:

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -20,6 +20,7 @@ from dask_expr import (
     DataFrame,
     Series,
     expr,
+    from_dict,
     from_pandas,
     is_scalar,
     isna,
@@ -2545,28 +2546,21 @@ def test_drop_columns_with_common_prefix():
     assert "prefix" in ddf.optimize().columns
 
 
-def test_series_repr():
+def test_to_datetime_repr():
     # https://github.com/dask/dask/issues/11016
-    import dask.dataframe as dd
 
-    df = dd.from_dict(
+    df = from_dict(
         {
-            "a": [1, 2, 3],
             "dt": [
                 "2023-01-04T00:00:00",
                 "2023-04-02T00:00:00",
                 "2023-01-01T00:00:00",
-            ],
+            ]
         },
         npartitions=1,
     )
+    to_datetime_repr = repr(to_datetime(df["dt"], format="%Y-%m-%dT%H:%M:%S"))
+    assert isinstance(to_datetime_repr, str)
 
-    assert isinstance(
-        repr(
-            dd.to_datetime(
-                df["dt"],
-                format="%Y-%m-%dT%H:%M:%S",
-            )
-        ),
-        str,
-    )
+    assert "Expr=ToDatetime(frame=df['dt']" in to_datetime_repr
+    assert "%Y-%m-%dT%H:%M:%S" in to_datetime_repr

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -2543,3 +2543,30 @@ def test_drop_columns_with_common_prefix():
 
     ddf = ddf.drop("prefix_foo", axis=1)
     assert "prefix" in ddf.optimize().columns
+
+
+def test_series_repr():
+    # https://github.com/dask/dask/issues/11016
+    import dask.dataframe as dd
+
+    df = dd.from_dict(
+        {
+            "a": [1, 2, 3],
+            "dt": [
+                "2023-01-04T00:00:00",
+                "2023-04-02T00:00:00",
+                "2023-01-01T00:00:00",
+            ],
+        },
+        npartitions=1,
+    )
+
+    assert isinstance(
+        repr(
+            dd.to_datetime(
+                df["dt"],
+                format="%Y-%m-%dT%H:%M:%S",
+            )
+        ),
+        str,
+    )

--- a/dask_expr/tests/test_concat.py
+++ b/dask_expr/tests/test_concat.py
@@ -22,8 +22,8 @@ def df(pdf):
 
 def test_concat_str(df):
     result = str(concat([df, df], join="inner"))
-    expected = "Expr=Concat(frames=[df, df], join=inner)"
-    assert expected in result
+    expected = "Expr=Concat(frames=[df, df], join='inner')"
+    assert expected in result, result
 
 
 def test_concat(pdf, df):


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/11016

In this example, it is trying to compare `self.meta == some_default` which is not uniquely defined for series object and therefore this raises.