### PR TITLE
Set divisions with divisions already known

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -2209,6 +2209,8 @@ Expr={expr}"""
         >>> ddf = ddf.set_index("timestamp", divisions=divisions, sorted=True)
         """
         if col is None and self.known_divisions:
+            if set_divisions:
+                return self
             return self.divisions
 
         if col is not None and set_divisions:

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -151,6 +151,15 @@ def test_set_index_blockwise_culling(df, pdf):
     assert_eq(result, pdf.set_index("x").head(10))
 
 
+def test_set_index_with_divisions_already_known():
+    ddf = timeseries(start="2021-01-01", end="2021-01-07", freq="1h").reset_index()
+    pdf = ddf.compute()
+    divisions = pd.date_range(start="2021-01-01", end="2021-01-07", freq="1D")
+
+    ddf2 = ddf.set_index("timestamp", sorted=True, divisions=divisions.tolist())
+    assert_eq(ddf2, pdf.set_index("timestamp"))
+
+
 @xfail_gpu("https://github.com/rapidsai/cudf/issues/10271")
 def test_explode():
     with dask.config.set({"dataframe.convert-string": False}):


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/11020

The `compute_current_divisions` kwarg `set_divisions` appears to be unused, at least in dask-expr. From an API perspective I find this a little weird and we should consider deprecating this