### PR TITLE
Nicer read_parquet prefix

### DIFF
--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -443,10 +443,12 @@ class Expr:
         return
 
     @functools.cached_property
+    def _funcname(self):
+        return funcname(type(self)).lower()
+
+    @functools.cached_property
     def _name(self):
-        return (
-            funcname(type(self)).lower() + "-" + _tokenize_deterministic(*self.operands)
-        )
+        return self._funcname + "-" + _tokenize_deterministic(*self.operands)
 
     @property
     def _meta(self):

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -103,7 +103,7 @@ class FusedIO(BlockwiseIO):
     @functools.cached_property
     def _name(self):
         return (
-            funcname(type(self.operand("_expr"))).lower()
+            self.operand("_expr")._funcname
             + "-fused-"
             + _tokenize_deterministic(*self.operands)
         )

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -632,9 +632,17 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             return _convert_to_list(columns_operand)
 
     @cached_property
+    def _funcname(self):
+        return "read_parquet"
+
+    @cached_property
     def _name(self):
-        return "read_parquet-" + _tokenize_deterministic(
-            funcname(type(self)), self.checksum, *self.operands[:-1]
+        return (
+            self._funcname
+            + "-"
+            + _tokenize_deterministic(
+                funcname(type(self)), self.checksum, *self.operands[:-1]
+            )
         )
 
     @property

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -633,10 +633,8 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
 
     @cached_property
     def _name(self):
-        return (
-            funcname(type(self)).lower()
-            + "-"
-            + _tokenize_deterministic(self.checksum, *self.operands[:-1])
+        return "read_parquet-" + _tokenize_deterministic(
+            funcname(type(self)), self.checksum, *self.operands[:-1]
         )
 
     @property


### PR DESCRIPTION
https://github.com/dask/dask-expr/issues/989 discusses how this prefix is a little too verbose. For me as a developer it is quite important to know which of the two implementations is currently running but ordinary users will likely not care.

This would be a simple approach to just include the logical name. 