### PR TITLE
Deprecate ``to/from_dask_dataframe`` API

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1257,8 +1257,10 @@ Expr={expr}"""
         **optimize_kwargs
             Key-word arguments to pass through to `optimize`.
         """
-        # TODO: Deprecate `to_dask_dataframe`
-        # See: https://github.com/dask/dask-expr/issues/905
+        warnings.warn(
+            "`to_dask_dataframe` is deprecated, please use `to_legacy_dataframe`.",
+            FutureWarning,
+        )
         return self.to_legacy_dataframe(*args, **kwargs)
 
     def to_legacy_dataframe(self, optimize: bool = True, **optimize_kwargs) -> _Frame:
@@ -4733,8 +4735,10 @@ def from_dask_dataframe(*args, **kwargs) -> FrameBase:
     optimize
         Whether to optimize the graph before conversion.
     """
-    # TODO: Deprecate `from_dask_dataframe`
-    # See: https://github.com/dask/dask-expr/issues/905
+    warnings.warn(
+        "`from_dask_dataframe` is deprecated, please use `from_legacy_dataframe`.",
+        FutureWarning,
+    )
     return from_legacy_dataframe(*args, **kwargs)
 
 

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -13,6 +13,7 @@ from dask_expr import (
     DataFrame,
     from_array,
     from_dask_array,
+    from_dask_dataframe,
     from_dict,
     from_legacy_dataframe,
     from_map,
@@ -220,6 +221,11 @@ def test_from_legacy_dataframe(optimize):
     assert isinstance(df.expr, Expr)
     assert_eq(df, ddf)
 
+    # Check deprecated API
+    with pytest.warns(FutureWarning, match="deprecated"):
+        df2 = from_dask_dataframe(ddf, optimize=optimize)
+        assert_eq(df, df2)
+
 
 @pytest.mark.parametrize("optimize", [True, False])
 def test_to_legacy_dataframe(optimize):
@@ -228,6 +234,11 @@ def test_to_legacy_dataframe(optimize):
     ddf = df.to_legacy_dataframe(optimize=optimize)
     assert isinstance(ddf, dd.core.DataFrame)
     assert_eq(df, ddf)
+
+    # Check deprecated API
+    with pytest.warns(FutureWarning, match="deprecated"):
+        ddf2 = df.to_dask_dataframe(optimize=optimize)
+        assert_eq(ddf, ddf2)
 
 
 @pytest.mark.parametrize("optimize", [True, False])


### PR DESCRIPTION
Deprecates `to/from_dask_dataframe` in favor of `to/from_legacy_dataframe`

- Follow-up to: https://github.com/dask/dask-expr/pull/987
- Blocked by: https://github.com/dask/dask/pull/11025