### PR TITLE
Register json and orc APIs for "pandas" dispatch

### DIFF
--- a/dask_expr/io/json.py
+++ b/dask_expr/io/json.py
@@ -1,8 +1,10 @@
 import pandas as pd
 
 from dask_expr import from_legacy_dataframe
+from dask_expr._backends import dataframe_creation_dispatch
 
 
+@dataframe_creation_dispatch.register_inplace("pandas")
 def read_json(
     url_path,
     orient="records",

--- a/dask_expr/io/orc.py
+++ b/dask_expr/io/orc.py
@@ -1,6 +1,8 @@
 from dask_expr import from_legacy_dataframe
+from dask_expr._backends import dataframe_creation_dispatch
 
 
+@dataframe_creation_dispatch.register_inplace("pandas")
 def read_orc(
     path,
     engine="pyarrow",


### PR DESCRIPTION
Minor change to enable cudf-specific `read_json` and `read_orc` logic to be defined in dask-cudf.