### PR TITLE
Fix backend dispatching for `read_csv`

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -13,7 +13,7 @@ import dask.dataframe.methods as methods
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-from dask import compute, get_annotations
+from dask import compute, config, get_annotations
 from dask.array import Array
 from dask.base import DaskMethodsMixin, is_dask_collection, named_schedulers
 from dask.core import flatten
@@ -4798,6 +4798,7 @@ def read_csv(
 ):
     from dask_expr.io.csv import ReadCSV
 
+    dataframe_backend = config.get("dataframe.backend", "pandas")
     if not isinstance(path, str):
         path = stringify_path(path)
     return new_collection(
@@ -4808,6 +4809,7 @@ def read_csv(
             storage_options=storage_options,
             kwargs=kwargs,
             header=header,
+            dataframe_backend=dataframe_backend,
         )
     )
 

--- a/dask_expr/io/csv.py
+++ b/dask_expr/io/csv.py
@@ -8,7 +8,6 @@ from dask_expr.io.io import BlockwiseIO, PartitionsFiltered
 class ReadCSV(PartitionsFiltered, BlockwiseIO):
     _parameters = [
         "filename",
-        "dataframe_backend",
         "columns",
         "header",
         "dtype_backend",
@@ -16,6 +15,7 @@ class ReadCSV(PartitionsFiltered, BlockwiseIO):
         "storage_options",
         "kwargs",
         "_series",
+        "dataframe_backend",
     ]
     _defaults = {
         "columns": None,
@@ -25,6 +25,7 @@ class ReadCSV(PartitionsFiltered, BlockwiseIO):
         "_partitions": None,
         "storage_options": None,
         "_series": False,
+        "dataframe_backend": "pandas",
     }
     _absorb_projections = True
 

--- a/dask_expr/io/csv.py
+++ b/dask_expr/io/csv.py
@@ -8,6 +8,7 @@ from dask_expr.io.io import BlockwiseIO, PartitionsFiltered
 class ReadCSV(PartitionsFiltered, BlockwiseIO):
     _parameters = [
         "filename",
+        "dataframe_backend",
         "columns",
         "header",
         "dtype_backend",
@@ -35,46 +36,48 @@ class ReadCSV(PartitionsFiltered, BlockwiseIO):
 
     @functools.cached_property
     def _ddf(self):
+        from dask import config
+
         # Temporary hack to simplify logic
+        with config.set({"dataframe.backend": self.dataframe_backend}):
+            kwargs = (
+                {"dtype_backend": self.dtype_backend}
+                if self.dtype_backend is not None
+                else {}
+            )
+            if self.kwargs is not None:
+                kwargs.update(self.kwargs)
 
-        kwargs = (
-            {"dtype_backend": self.dtype_backend}
-            if self.dtype_backend is not None
-            else {}
-        )
-        if self.kwargs is not None:
-            kwargs.update(self.kwargs)
+            columns = _convert_to_list(self.operand("columns"))
+            if columns is None:
+                pass
+            elif "include_path_column" in self.kwargs:
+                flag = self.kwargs["include_path_column"]
+                if flag is True:
+                    column_to_remove = "path"
+                elif isinstance(flag, str):
+                    column_to_remove = flag
+                else:
+                    column_to_remove = None
 
-        columns = _convert_to_list(self.operand("columns"))
-        if columns is None:
-            pass
-        elif "include_path_column" in self.kwargs:
-            flag = self.kwargs["include_path_column"]
-            if flag is True:
-                column_to_remove = "path"
-            elif isinstance(flag, str):
-                column_to_remove = flag
-            else:
-                column_to_remove = None
+                columns = [c for c in columns if c != column_to_remove]
 
-            columns = [c for c in columns if c != column_to_remove]
+                if not columns:
+                    meta = self.operation(
+                        self.filename,
+                        header=self.header,
+                        storage_options=self.storage_options,
+                        **kwargs,
+                    )._meta
+                    columns = [list(meta.columns)[0]]
 
-            if not columns:
-                meta = self.operation(
-                    self.filename,
-                    header=self.header,
-                    storage_options=self.storage_options,
-                    **kwargs,
-                )._meta
-                columns = [list(meta.columns)[0]]
-
-        return self.operation(
-            self.filename,
-            usecols=columns,
-            header=self.header,
-            storage_options=self.storage_options,
-            **kwargs,
-        )
+            return self.operation(
+                self.filename,
+                usecols=columns,
+                header=self.header,
+                storage_options=self.storage_options,
+                **kwargs,
+            )
 
     @functools.cached_property
     def _meta(self):

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -6,6 +6,7 @@ import dask.dataframe as dd
 import numpy as np
 import pyarrow.parquet as pq
 import pytest
+from dask import config
 from dask.array.utils import assert_eq as array_assert_eq
 from dask.dataframe.utils import assert_eq, make_meta
 
@@ -181,6 +182,11 @@ def test_io_culling(tmpdir, fmt):
         df = read_csv(tmpdir + "/*")
     else:
         df = from_pandas(pdf, 2)
+
+    # Check that original pdf type is conserved
+    with config.set({"dataframe.backend": "pandas"}):
+        assert type(df.head()) == type(pdf)
+
     df = (df[["a", "b"]] + 1).partitions[1]
     df2 = optimize(df)
 


### PR DESCRIPTION
Backend dispatching doesn't currently work in all cases for `read_cudf`, because the `operation` property may be accessed outside a `config` context block. This PR resolves the issue by adding a `"dataframe_backend"` parameter.