### PR TITLE
Fuse more aggressively if parquet files are tiny

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -738,6 +738,9 @@ Expr={expr}"""
         else:
             bad_types = (FrameBase,)
         if isinstance(values, bad_types):
+            if values.ndim == 1 and values.npartitions == 1:
+                # Can broadcast
+                return new_collection(expr.Isin(self, values=values))
             raise NotImplementedError("Passing a %r to `isin`" % typename(type(values)))
 
         # We wrap values in a delayed for two reasons:

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -738,7 +738,11 @@ Expr={expr}"""
         else:
             bad_types = (FrameBase,)
         if isinstance(values, bad_types):
-            if values.ndim == 1 and values.npartitions == 1:
+            if (
+                isinstance(values, FrameBase)
+                and values.ndim == 1
+                and values.npartitions == 1
+            ):
                 # Can broadcast
                 return new_collection(expr.Isin(self, values=values))
             raise NotImplementedError("Passing a %r to `isin`" % typename(type(values)))

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -49,6 +49,7 @@ from dask.utils import (
     IndexCallable,
     M,
     derived_from,
+    get_default_shuffle_method,
     get_meta_library,
     key_split,
     maybe_pluralize,
@@ -893,6 +894,19 @@ Expr={expr}"""
                 )
         elif pd.api.types.is_list_like(on) and not is_dask_collection(on):
             on = list(on)
+
+        if (shuffle_method or get_default_shuffle_method()) == "p2p":
+            from distributed.shuffle._arrow import check_dtype_support
+
+            check_dtype_support(self._meta)
+
+            if any(not isinstance(c, str) for c in self._meta.columns):
+                unsupported = {
+                    c: type(c) for c in self._meta.columns if not isinstance(c, str)
+                }
+                raise TypeError(
+                    f"p2p requires all column names to be str, found: {unsupported}",
+                )
 
         # Returned shuffled result
         return new_collection(

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -49,7 +49,6 @@ from dask.utils import (
     IndexCallable,
     M,
     derived_from,
-    get_default_shuffle_method,
     get_meta_library,
     key_split,
     maybe_pluralize,
@@ -894,19 +893,6 @@ Expr={expr}"""
                 )
         elif pd.api.types.is_list_like(on) and not is_dask_collection(on):
             on = list(on)
-
-        if (shuffle_method or get_default_shuffle_method()) == "p2p":
-            from distributed.shuffle._arrow import check_dtype_support
-
-            check_dtype_support(self._meta)
-
-            if any(not isinstance(c, str) for c in self._meta.columns):
-                unsupported = {
-                    c: type(c) for c in self._meta.columns if not isinstance(c, str)
-                }
-                raise TypeError(
-                    f"p2p requires all column names to be str, found: {unsupported}",
-                )
 
         # Returned shuffled result
         return new_collection(

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -3047,12 +3047,12 @@ def are_co_aligned(*exprs):
             # Scalars are valid ancestors that are always broadcastable,
             # so don't walk through them
             continue
+        elif isinstance(e, (_DelayedExpr, Isin)):
+            continue
         elif isinstance(e, (Blockwise, CumulativeAggregations, Reduction)):
             # TODO: Capture this in inheritance logic
             dependencies = e.dependencies()
             stack.extend(dependencies)
-        elif isinstance(e, _DelayedExpr):
-            continue
         else:
             ancestors.append(e)
 

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1362,6 +1362,9 @@ class Isin(Elemwise):
     def _meta(self):
         return make_meta(meta_nonempty(self.frame._meta).isin([1]))
 
+    def _broadcast_dep(self, dep: Expr):
+        return dep.npartitions == 1
+
 
 class Clip(Elemwise):
     _projection_passthrough = True

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -86,7 +86,7 @@ def _as_dict(key, value):
 
 def _adjust_split_out_for_group_keys(npartitions, by):
     if len(by) == 1:
-        return math.ceil(npartitions / 10)
+        return math.ceil(npartitions / 15)
     return math.ceil(npartitions / (10 / (len(by) - 1)))
 
 

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -85,6 +85,8 @@ def _as_dict(key, value):
 
 
 def _adjust_split_out_for_group_keys(npartitions, by):
+    if len(by) == 1:
+        return math.ceil(npartitions / 10)
     return math.ceil(npartitions / (10 / (len(by) - 1)))
 
 
@@ -222,7 +224,7 @@ class GroupByApplyConcatApply(ApplyConcatApply, GroupByBase):
         return self.frame.columns
 
     def _tune_down(self):
-        if len(self.by) > 1 and self.operand("split_out") is None:
+        if self.operand("split_out") is None:
             return self.substitute_parameters(
                 {
                     "split_out": functools.partial(
@@ -674,7 +676,7 @@ class GroupByReduction(Reduction, GroupByBase):
     _chunk_cls = GroupByChunk
 
     def _tune_down(self):
-        if len(self.by) > 1 and self.operand("split_out") is None:
+        if self.operand("split_out") is None:
             return self.substitute_parameters(
                 {
                     "split_out": functools.partial(

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -113,7 +113,9 @@ class ShuffleBase(Expr):
         if isinstance(parent, Projection):
             # Move the column projection to come
             # before the abstract Shuffle
-            projection = determine_column_projection(self, parent, dependents)
+            projection = _convert_to_list(
+                determine_column_projection(self, parent, dependents)
+            )
             partitioning_index = self._partitioning_index
 
             target = self.frame

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -1001,17 +1001,16 @@ class ReadParquetPyarrowFS(ReadParquet):
 
     @property
     def _fusion_compression_factor(self):
-        if self.operand("columns") is None:
-            return 1
         approx_stats = self.approx_statistics()
         total_uncompressed = 0
         after_projection = 0
-        col_op = self.operand("columns")
+        col_op = self.operand("columns") or self.columns
         for col in approx_stats["columns"]:
             total_uncompressed += col["total_uncompressed_size"]
             if col["path_in_schema"] in col_op:
                 after_projection += col["total_uncompressed_size"]
 
+        total_uncompressed = max(total_uncompressed, 100_000_000)
         return max(after_projection / total_uncompressed, 0.001)
 
     def _filtered_task(self, index: int):

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -1012,9 +1012,7 @@ class ReadParquetPyarrowFS(ReadParquet):
             if col["path_in_schema"] in col_op:
                 after_projection += col["total_uncompressed_size"]
 
-        min_size = (
-            dask.config.get("dataframe.parquet.minimum-partition-size") or 75_000_000
-        )
+        min_size = dask.config.get("dataframe.parquet.minimum-partition-size")
         total_uncompressed = max(total_uncompressed, min_size)
         return max(after_projection / total_uncompressed, 0.001)
 

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -1010,7 +1010,7 @@ class ReadParquetPyarrowFS(ReadParquet):
             if col["path_in_schema"] in col_op:
                 after_projection += col["total_uncompressed_size"]
 
-        total_uncompressed = max(total_uncompressed, 100_000_000)
+        total_uncompressed = max(total_uncompressed, 75_000_000)
         return max(after_projection / total_uncompressed, 0.001)
 
     def _filtered_task(self, index: int):

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -319,12 +319,12 @@ def test_groupby_agg_column_projection(pdf, df):
 
 def test_groupby_split_every(pdf):
     df = from_pandas(pdf, npartitions=16)
-    query = df.groupby("x").sum()
+    query = df.groupby("x").sum(split_out=1)
     tree_reduce_node = list(query.optimize(fuse=False).find_operations(TreeReduce))
     assert len(tree_reduce_node) == 1
     assert tree_reduce_node[0].split_every == 8
 
-    query = df.groupby("x").aggregate({"y": "sum"})
+    query = df.groupby("x").aggregate({"y": "sum"}, split_out=1)
     tree_reduce_node = list(query.optimize(fuse=False).find_operations(TreeReduce))
     assert len(tree_reduce_node) == 1
     assert tree_reduce_node[0].split_every == 8
@@ -352,7 +352,7 @@ def test_split_out_automatically():
     pdf = pd.DataFrame({"a": [1, 2, 3] * 1_000, "b": 1, "c": 1, "d": 1})
     df = from_pandas(pdf, npartitions=500)
     q = df.groupby("a").sum()
-    assert q.optimize().npartitions == 1
+    assert q.optimize().npartitions == 34
     expected = pdf.groupby("a").sum()
     assert_eq(q, expected)
 


### PR DESCRIPTION
This PR does a few things:

- Fuse tiny parquet files more aggressive up to 75MB per partition (in memory)
- set split_out in groupby also for length one grouping keys (this is more conservative and helps uf get rid of a few split_out=True optimisations in benchmarks)
- make isin work with npartitions=1 Dask Series objects

Here is an AB test for this (fuse tag)

https://github.com/coiled/benchmarks/actions/runs/8709180542