### PR TITLE
Fix bug in ``Series`` reductions

### DIFF
--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -251,6 +251,8 @@ class ShuffleReduce(Expr):
         if self.shuffle_by_index is not False:
             if is_series_like(self._meta) and is_series_like(self.frame._meta):
                 shuffled = shuffled[shuffled.columns[0]]
+                if shuffled.name == "__series__":
+                    shuffled = RenameSeries(shuffled, self.frame._meta.name)
             elif is_index_like(self._meta):
                 column = shuffled.columns[0]
                 divs = None if shuffled.divisions[0] is None else shuffled.divisions

--- a/dask_expr/tests/test_reductions.py
+++ b/dask_expr/tests/test_reductions.py
@@ -95,6 +95,12 @@ def test_drop_duplicates(pdf, df, split_every, split_out):
     )
 
 
+def test_series_reduction_name():
+    ser = from_pandas(pd.Series(range(10)), npartitions=2)
+    df = ser.drop_duplicates().to_frame()
+    assert_eq(df, df)
+
+
 @pytest.mark.parametrize("split_every", [False, None, 5])
 @pytest.mark.parametrize("split_out", [1, True])
 def test_value_counts(pdf, df, split_every, split_out):


### PR DESCRIPTION
After reducing a `Series`, we need to convert back from the temporary `"__series__"` name. This is currently breaking several tests in `cugraph`.