### PR TITLE
Fix default name conversion in `ToFrame`

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1622,6 +1622,7 @@ class ToFrame(Elemwise):
             return set(self.columns)
         return unique_mapping
 
+
 class ToFrameIndex(Elemwise):
     _parameters = ["frame", "index", "name"]
     _defaults = {"name": no_default, "index": True}

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1613,8 +1613,14 @@ class ToFrame(Elemwise):
     _keyword_only = ["name"]
     operation = M.to_frame
     _filter_passthrough = True
-    _preserves_partitioning_information = True
 
+    @functools.cached_property
+    def unique_partition_mapping_columns_from_shuffle(self):
+        unique_mapping = self.frame.unique_partition_mapping_columns_from_shuffle
+        if set(self.frame.columns) == unique_mapping:
+            # Account for default name conversion
+            return set(self.columns)
+        return unique_mapping
 
 class ToFrameIndex(Elemwise):
     _parameters = ["frame", "index", "name"]

--- a/dask_expr/tests/test_merge.py
+++ b/dask_expr/tests/test_merge.py
@@ -1011,3 +1011,19 @@ def test_merge_suffix_projections():
     expected = df.merge(df, on="a")
     expected = expected[expected["c_x"] == "A"]["c_y"]
     assert_eq(result, expected)
+
+
+def test_merge_after_rename():
+    pleft = pd.Series(range(10))
+    pleft = pleft.drop_duplicates().to_frame()
+    pleft.columns = ["a"]
+
+    left = from_pandas(pd.Series(range(10)), npartitions=2)
+    left = left.drop_duplicates().to_frame()
+    left.columns = ["a"]
+
+    right = pd.DataFrame({"a": [1, 2] * 5})
+
+    expected = pleft.merge(right, how="inner")
+    result = left.merge(right, how="inner")
+    assert_eq(result, expected)

--- a/dask_expr/tests/test_merge.py
+++ b/dask_expr/tests/test_merge.py
@@ -1023,7 +1023,6 @@ def test_merge_after_rename():
     left.columns = ["a"]
 
     right = pd.DataFrame({"a": [1, 2] * 5})
-
     expected = pleft.merge(right, how="inner")
     result = left.merge(right, how="inner")
     assert_eq(result, expected)


### PR DESCRIPTION
Possible fix for a subtle optimization bug that shows up when an unnamed `Series` is shuffled and then converted to a `DataFrame` and merged. Definitely a bit of a "corner case", but does show up in `cugraph` CI.