### PR TITLE
reduce pickle size of parquet fragments

### DIFF
--- a/dask_expr/io/tests/test_parquet.py
+++ b/dask_expr/io/tests/test_parquet.py
@@ -561,6 +561,22 @@ async def test_parquet_distriuted(c, s, a, b, tmpdir, filesystem):
     assert_eq(await c.gather(c.compute(df.optimize())), pdf)
 
 
+@pytest.mark.filterwarnings("error")
+def test_parquet_distriuted2(tmpdir, filesystem):
+    from distributed import Client, LocalCluster
+
+    with LocalCluster(processes=False, n_workers=2) as cluster:
+        with Client(cluster) as client:  # noqa: F841
+            pdf = pd.DataFrame({"x": [1, 4, 3, 2, 0, 5]})
+            [_make_file(tmpdir, df=pdf, filename=f"{x}.parquet") for x in range(10)]
+            df = read_parquet(
+                tmpdir,
+                filesystem=filesystem,
+            )
+            res = df.compute()
+            assert res is not None
+
+
 def test_index_only_from_parquet(tmpdir):
     pdf = pd.DataFrame({"foo": range(5)}, index=range(50, 55))
     pdf.to_parquet(tmpdir + "/test.parquet")


### PR DESCRIPTION
This is still early stage.

I wondered why our graph is always very large in bytes when using this parquet interface and dug a little. I found that the fragments are indeed quite large. What I found so far

- Something like the partition expression is a pyarrow.compute Expression. Even the vanilla True, i.e. "read all partitions" expression packs already 700KB and this is attached to every file.
- The parquetfileformat object is in a similar vicinity although we're rarely if ever specifiying anything and we could just as well use the default
- Most importantly, though, I discovered that most things we're unpacking manually in this Fragment are ad-hoc wrapped C objects, i.e. every time I invoke `Fragement.filesystem` I get a new python object even though the underlying C object is identical. This confuses pickle. Pickle typically deduplicates objects but with this it doesn't stand a chance.

We may be able to ditch this wrapper for newer pyarrow versions entirely but for old ones we may have to be clever at deduplicating things. I still have to run some tests but I suspect this will reduce graph size by orders of magnitude