### PR TITLE
Generalize ``get_dummies``

### DIFF
--- a/dask_expr/_dummies.py
+++ b/dask_expr/_dummies.py
@@ -156,6 +156,7 @@ class GetDummies(Blockwise):
         "prefix_sep",
         "dummy_na",
         "columns",
+        "sparse",
         "drop_first",
         "dtype",
     ]
@@ -164,9 +165,12 @@ class GetDummies(Blockwise):
         "prefix_sep": "_",
         "dummy_na": False,
         "columns": None,
+        "sparse": False,
         "drop_first": False,
         "dtype": bool,
     }
+    # cudf has extra kwargs after `columns`
+    _keyword_only = ["sparse", "drop_first", "dtype"]
 
     @staticmethod
     def operation(df, *args, **kwargs):

--- a/dask_expr/tests/test_dummies.py
+++ b/dask_expr/tests/test_dummies.py
@@ -1,3 +1,4 @@
+import pandas
 import pytest
 
 from dask_expr import from_pandas, get_dummies
@@ -10,9 +11,11 @@ pd = _backend_library()
     "data",
     [
         pd.Series([1, 1, 1, 2, 2, 1, 3, 4], dtype="category"),
-        pd.Series(pd.Categorical([1, 1, 1, 2, 2, 1, 3, 4], categories=[4, 3, 2, 1])),
+        pd.Series(
+            pandas.Categorical([1, 1, 1, 2, 2, 1, 3, 4], categories=[4, 3, 2, 1])
+        ),
         pd.DataFrame(
-            {"a": [1, 2, 3, 4, 4, 3, 2, 1], "b": pd.Categorical(list("abcdabcd"))}
+            {"a": [1, 2, 3, 4, 4, 3, 2, 1], "b": pandas.Categorical(list("abcdabcd"))}
         ),
     ],
 )
@@ -22,4 +25,4 @@ def test_get_dummies(data):
     ddata = from_pandas(data, 2)
     res = get_dummies(ddata)
     assert_eq(res, exp)
-    pd.testing.assert_index_equal(res.columns, exp.columns)
+    pandas.testing.assert_index_equal(res.columns, exp.columns)


### PR DESCRIPTION
- Generalizes `get_dummies`/`GetDummies` to work with `cudf`
- Fixes a minor bug (missing `"sparse"` parameter)