### PR TITLE
Add cache  argument to ``lower_once``

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -566,8 +566,8 @@ Expr={expr}"""
     def simplify(self):
         return new_collection(self.expr.simplify())
 
-    def lower_once(self):
-        return new_collection(self.expr.lower_once())
+    def lower_once(self, lowered: dict):
+        return new_collection(self.expr.lower_once(lowered))
 
     def optimize(self, fuse: bool = True):
         """Optimizes the DataFrame.

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -566,8 +566,8 @@ Expr={expr}"""
     def simplify(self):
         return new_collection(self.expr.simplify())
 
-    def lower_once(self, lowered: dict):
-        return new_collection(self.expr.lower_once(lowered))
+    def lower_once(self):
+        return new_collection(self.expr.lower_once({}))
 
     def optimize(self, fuse: bool = True):
         """Optimizes the DataFrame.

--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -386,7 +386,12 @@ class Expr:
     def _simplify_up(self, parent, dependents):
         return
 
-    def lower_once(self):
+    def lower_once(self, cache=None):
+        # Check for a chached result
+        cache = {} if cache is None else cache
+        if self._name in cache:
+            return self._instances[cache[self._name]]
+
         expr = self
 
         # Lower this node
@@ -401,7 +406,7 @@ class Expr:
         changed = False
         for operand in out.operands:
             if isinstance(operand, Expr):
-                new = operand.lower_once()
+                new = operand.lower_once(cache)
                 if new._name != operand._name:
                     changed = True
             else:
@@ -411,6 +416,8 @@ class Expr:
         if changed:
             out = type(out)(*new_operands)
 
+        # Cache the result and return
+        cache[self._name] = out._name
         return out
 
     def lower_completely(self) -> Expr:
@@ -432,8 +439,9 @@ class Expr:
         """
         # Lower until nothing changes
         expr = self
+        cache = {}
         while True:
-            new = expr.lower_once()
+            new = expr.lower_once(cache)
             if new._name == expr._name:
                 break
             expr = new

--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -386,7 +386,7 @@ class Expr:
     def _simplify_up(self, parent, dependents):
         return
 
-    def lower_once(self, *, lowered=None):
+    def lower_once(self, lowered: dict):
         # Check for a chached result
         try:
             return lowered[self._name]
@@ -407,7 +407,7 @@ class Expr:
         changed = False
         for operand in out.operands:
             if isinstance(operand, Expr):
-                new = operand.lower_once(lowered=lowered)
+                new = operand.lower_once(lowered)
                 if new._name != operand._name:
                     changed = True
             else:
@@ -441,7 +441,7 @@ class Expr:
         expr = self
         lowered = {}
         while True:
-            new = expr.lower_once(lowered=lowered)
+            new = expr.lower_once(lowered)
             if new._name == expr._name:
                 break
             expr = new

--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -390,7 +390,7 @@ class Expr:
         # Check for a chached result
         cache = {} if cache is None else cache
         if self._name in cache:
-            return self._instances[cache[self._name]]
+            return cache[self._name]
 
         expr = self
 
@@ -417,7 +417,7 @@ class Expr:
             out = type(out)(*new_operands)
 
         # Cache the result and return
-        cache[self._name] = out._name
+        cache[self._name] = out
         return out
 
     def lower_completely(self) -> Expr:

--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -386,10 +386,10 @@ class Expr:
     def _simplify_up(self, parent, dependents):
         return
 
-    def lower_once(self, *, cache=None):
+    def lower_once(self, *, lowered=None):
         # Check for a chached result
         try:
-            return cache[self._name]
+            return lowered[self._name]
         except KeyError:
             pass
 
@@ -407,7 +407,7 @@ class Expr:
         changed = False
         for operand in out.operands:
             if isinstance(operand, Expr):
-                new = operand.lower_once(cache=cache)
+                new = operand.lower_once(lowered=lowered)
                 if new._name != operand._name:
                     changed = True
             else:
@@ -418,7 +418,7 @@ class Expr:
             out = type(out)(*new_operands)
 
         # Cache the result and return
-        return cache.setdefault(self._name, out)
+        return lowered.setdefault(self._name, out)
 
     def lower_completely(self) -> Expr:
         """Lower an expression completely
@@ -439,9 +439,9 @@ class Expr:
         """
         # Lower until nothing changes
         expr = self
-        cache = {}
+        lowered = {}
         while True:
-            new = expr.lower_once(cache=cache)
+            new = expr.lower_once(lowered=lowered)
             if new._name == expr._name:
                 break
             expr = new

--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -386,11 +386,12 @@ class Expr:
     def _simplify_up(self, parent, dependents):
         return
 
-    def lower_once(self, cache=None):
+    def lower_once(self, *, cache=None):
         # Check for a chached result
-        cache = {} if cache is None else cache
-        if self._name in cache:
+        try:
             return cache[self._name]
+        except KeyError:
+            pass
 
         expr = self
 
@@ -406,7 +407,7 @@ class Expr:
         changed = False
         for operand in out.operands:
             if isinstance(operand, Expr):
-                new = operand.lower_once(cache)
+                new = operand.lower_once(cache=cache)
                 if new._name != operand._name:
                     changed = True
             else:
@@ -417,8 +418,7 @@ class Expr:
             out = type(out)(*new_operands)
 
         # Cache the result and return
-        cache[self._name] = out
-        return out
+        return cache.setdefault(self._name, out)
 
     def lower_completely(self) -> Expr:
         """Lower an expression completely
@@ -441,7 +441,7 @@ class Expr:
         expr = self
         cache = {}
         while True:
-            new = expr.lower_once(cache)
+            new = expr.lower_once(cache=cache)
             if new._name == expr._name:
                 break
             expr = new


### PR DESCRIPTION
Adds simple logic to `lower_once` so that we avoid re-lowering an expression (and its children) multiple times.

Addresses the `Expr.dask/compute` component of https://github.com/dask/dask-expr/issues/1055: `ddf.dask` is ~200 times faster for python-only reproducer.