### PR TITLE
Use `is_categorical_dtype` dispatch for `sort_values`

### DIFF
--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -1306,7 +1306,7 @@ def _calculate_divisions(
     if is_index_like(other._meta):
         other = ToSeriesIndex(other)
 
-    if is_categorical_dtype(other._meta):
+    if is_categorical_dtype(other._meta.dtype):
         other = new_collection(other).cat.as_ordered()._expr
 
     try:

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -8,6 +8,7 @@ import pandas as pd
 import tlz as toolz
 from dask import compute
 from dask.dataframe.core import _concat, make_meta
+from dask.dataframe.dispatch import is_categorical_dtype
 from dask.dataframe.shuffle import (
     barrier,
     collect,
@@ -1305,7 +1306,7 @@ def _calculate_divisions(
     if is_index_like(other._meta):
         other = ToSeriesIndex(other)
 
-    if isinstance(other._meta.dtype, pd.CategoricalDtype):
+    if is_categorical_dtype(other._meta):
         other = new_collection(other).cat.as_ordered()._expr
 
     try:


### PR DESCRIPTION
Minor revision to https://github.com/dask/dask-expr/pull/1058 to support categorical columns in cudf (my mistake for missing this detail when I reviewed that PR).

Note that I cannot add gpuci coverage until https://github.com/rapidsai/cudf/issues/15778 is resolved (which I'd rather not block this fix for).