### PR TITLE
Add `how="leftanti"` support for cudf-backed merge

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -2818,7 +2818,7 @@ class DataFrame(FrameBase):
         Parameters
         ----------
         right: dask.dataframe.DataFrame
-        how : {'left', 'right', 'outer', 'inner', 'leftsemi'}, default: 'inner'
+        how : {'left', 'right', 'outer', 'inner', 'leftsemi', 'leftanti'}, default: 'inner'
             How to handle the operation of the two objects:
 
             - left: use calling frame's index (or column if on is specified)
@@ -2830,6 +2830,9 @@ class DataFrame(FrameBase):
               on is specified) with other frame's index, preserving the order
               of the calling's one
             - leftsemi: Choose all rows in left where the join keys can be found
+              in right. Won't duplicate rows if the keys are duplicated in right.
+              Drops all columns from right. Only supported with 'cudf' backend.
+            - leftanti: Choose all rows in left where the join keys cannot be found
               in right. Won't duplicate rows if the keys are duplicated in right.
               Drops all columns from right.
 
@@ -5628,11 +5631,12 @@ def merge(
     if on and not left_on and not right_on:
         left_on = right_on = on
 
-    supported_how = ("left", "right", "outer", "inner", "leftsemi")
+    supported_how = ("left", "right", "outer", "inner", "leftsemi", "leftanti")
     if how not in supported_how:
         raise ValueError(
             f"dask.dataframe.merge does not support how='{how}'."
             f"Options are: {supported_how}."
+            "Note that 'leftanti' is only an dask_cudf option."
         )
 
     if how == "leftsemi":

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -102,7 +102,7 @@ class Merge(Expr):
             if predicate_columns is None:
                 return False
             if predicate_columns.issubset(self.left.columns):
-                return self.how in ("left", "inner", "leftsemi")
+                return self.how in ("left", "inner", "leftsemi", "leftanti")
             elif predicate_columns.issubset(self.right.columns):
                 return self.how in ("right", "inner")
             elif len(predicate_columns) > 0:
@@ -242,7 +242,7 @@ class Merge(Expr):
             elif (
                 use_left
                 and self.right.npartitions == 1
-                and self.how in ("inner", "left", "leftsemi")
+                and self.how in ("inner", "left", "leftsemi", "leftanti")
             ):
                 return self.left.divisions
             else:
@@ -283,7 +283,7 @@ class Merge(Expr):
         s_method = self.shuffle_method or get_default_shuffle_method()
         if (
             s_method in ("tasks", "p2p")
-            and self.how in ("inner", "left", "right", "leftsemi")
+            and self.how in ("inner", "left", "right", "leftsemi", "leftanti")
             and self.how != broadcast_side
             and broadcast is not False
         ):
@@ -301,7 +301,7 @@ class Merge(Expr):
             or self.left.npartitions == 1
             and self.how in ("right", "inner")
             or self.right.npartitions == 1
-            and self.how in ("left", "inner", "leftsemi")
+            and self.how in ("left", "inner", "leftsemi", "leftanti")
         )
 
     @functools.cached_property
@@ -776,7 +776,7 @@ class BroadcastJoin(Merge, PartitionsFiltered):
                     ),
                     (bcast_name, j),
                 ]
-                if self.broadcast_side in ("left", "leftsemi"):
+                if self.broadcast_side in ("left", "leftsemi", "leftanti"):
                     _merge_args.reverse()
 
                 inter_key = (inter_name, part_out, j)


### PR DESCRIPTION
Looks like we should unblocked to support left anti joins when `dataframe.backend="cudf"`, similar to the case in legacy Dask dataframe:

https://github.com/dask/dask/blob/df4de6ea53054790b09006c8ea68ef8725d39025/dask/dataframe/multi.py#L565

Note that like the legacy code, we'll fail somewhere down in the comptutation stack if we try this on CPU - not sure if it makes sense to check the backend if `how="leftanti"` and eagerly raise a `NotImplementedError` if `dataframe.backend != "cudf"`.

cc @rjzamora