### PR TITLE
Refactor shuffle method to handle invalid columns

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -923,7 +923,7 @@ Expr={expr}"""
                 raise TypeError(
                     f"p2p requires all column names to be str, found: {unsupported}",
                 )
-
+        # Returned shuffled result
         return new_collection(
             RearrangeByColumn(
                 self,

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -900,14 +900,20 @@ Expr={expr}"""
             if pd.api.types.is_list_like(on) and not is_dask_collection(on):
                 on = list(on)
             elif isinstance(on, str):
-                on =[on] #this doesn't split the string into characters, it just makes a list with the string as the only element
-            # Check if 'on' is a valid column
-            bad_cols = [index_col for index_col in on if (index_col not in self.columns) and (index_col != self.index.name)]
-            # Adding this check so it collects all bad columns at once rather than requiring multiple runs
+                on = [on]
+            bad_cols = [
+                index_col
+                for index_col in on
+                if (index_col not in self.columns) and (index_col != self.index.name)
+            ]
             if len(bad_cols) == 1:
-                raise KeyError(f"Cannot shuffle on '{bad_cols[0]}', as it is not in target DataFrame columns")
+                raise KeyError(
+                    f"Cannot shuffle on '{bad_cols[0]}', as it is not in target DataFrame columns"
+                )
             elif len(bad_cols) > 1:
-                raise KeyError(f"Cannot shuffle on {bad_cols}, as they are not in target DataFrame columns")
+                raise KeyError(
+                    f"Cannot shuffle on {bad_cols}, as they are not in target DataFrame columns"
+                )
 
         if (shuffle_method or get_default_shuffle_method()) == "p2p":
             from distributed.shuffle._arrow import check_dtype_support

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -896,8 +896,18 @@ Expr={expr}"""
                 raise TypeError(
                     "index must be aligned with the DataFrame to use as shuffle index."
                 )
-        elif pd.api.types.is_list_like(on) and not is_dask_collection(on):
-            on = list(on)
+        else:
+            if pd.api.types.is_list_like(on) and not is_dask_collection(on):
+                on = list(on)
+            elif isinstance(on, str):
+                on =[on] #this doesn't split the string into characters, it just makes a list with the string as the only element
+            # Check if 'on' is a valid column
+            bad_cols = [index_col for index_col in on if (index_col not in self.columns) and (index_col != self.index.name)]
+            # Adding this check so it collects all bad columns at once rather than requiring multiple runs
+            if len(bad_cols) == 1:
+                raise KeyError(f"Cannot shuffle on '{bad_cols[0]}', as it is not in target DataFrame columns")
+            elif len(bad_cols) > 1:
+                raise KeyError(f"Cannot shuffle on {bad_cols}, as they are not in target DataFrame columns")
 
         if (shuffle_method or get_default_shuffle_method()) == "p2p":
             from distributed.shuffle._arrow import check_dtype_support
@@ -912,7 +922,6 @@ Expr={expr}"""
                     f"p2p requires all column names to be str, found: {unsupported}",
                 )
 
-        # Returned shuffled result
         return new_collection(
             RearrangeByColumn(
                 self,

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -899,20 +899,16 @@ Expr={expr}"""
         else:
             if pd.api.types.is_list_like(on) and not is_dask_collection(on):
                 on = list(on)
-            elif isinstance(on, str):
+            elif isinstance(on, str) or isinstance(on, int):
                 on = [on]
             bad_cols = [
                 index_col
                 for index_col in on
                 if (index_col not in self.columns) and (index_col != self.index.name)
             ]
-            if len(bad_cols) == 1:
+            if bad_cols:
                 raise KeyError(
-                    f"Cannot shuffle on '{bad_cols[0]}', as it is not in target DataFrame columns"
-                )
-            elif len(bad_cols) > 1:
-                raise KeyError(
-                    f"Cannot shuffle on {bad_cols}, as they are not in target DataFrame columns"
+                    f"Cannot shuffle on {bad_cols}, column(s) not in dataframe to shuffle"
                 )
 
         if (shuffle_method or get_default_shuffle_method()) == "p2p":

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -140,7 +140,6 @@ def test_shuffle_str_column_not_in_dataframe(df):
 
 
 def test_shuffle_mixed_list_column_not_in_dataframe(df):
-    # not all cols in list are not in dataframe
     with pytest.raises(
         KeyError,
         match="Cannot shuffle on",
@@ -151,7 +150,6 @@ def test_shuffle_mixed_list_column_not_in_dataframe(df):
 
 
 def test_shuffle_list_column_not_in_dataframe(df):
-    # all cols in list are not in dataframe
     with pytest.raises(KeyError, match=r"Cannot shuffle on") as excinfo:
         df.shuffle(["zz", "z"])
     assert "z" in str(excinfo.value)

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -134,18 +134,21 @@ def test_shuffle_str_column_not_in_dataframe(df):
     # ddf = from_pandas(pdf, npartitions=10)
     with pytest.raises(
         KeyError,
-        match="Cannot shuffle on 'z', as it is not in target DataFrame columns",
-    ):
+        match="Cannot shuffle on",
+    ) as execinfo:
         df.shuffle(on="z")  # .compute()
+    assert "z" in str(execinfo.value)
 
 
 def test_shuffle_mixed_list_column_not_in_dataframe(df):
     # not all cols in list are not in dataframe
     with pytest.raises(
         KeyError,
-        match="Cannot shuffle on 'z', as it is not in target DataFrame columns",
-    ):
+        match="Cannot shuffle on",
+    ) as execinfo:
         df.shuffle(["x", "z"])
+    assert "z" in str(execinfo.value)
+    assert "x" not in str(execinfo.value)
 
 
 def test_shuffle_list_column_not_in_dataframe(df):

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -132,29 +132,33 @@ def test_task_shuffle_index(npartitions, max_branch, pdf):
 
 def test_shuffle_str_column_not_in_dataframe(df):
     # ddf = from_pandas(pdf, npartitions=10)
-    with pytest.raises(KeyError, 
-    match="Cannot shuffle on 'z', as it is not in target DataFrame columns"
+    with pytest.raises(
+        KeyError,
+        match="Cannot shuffle on 'z', as it is not in target DataFrame columns",
     ):
-        df.shuffle(on="z")#.compute()
+        df.shuffle(on="z")  # .compute()
+
 
 def test_shuffle_mixed_list_column_not_in_dataframe(df):
     # not all cols in list are not in dataframe
-    with pytest.raises(KeyError,
-    match= "Cannot shuffle on 'z', as it is not in target DataFrame columns"
-    ): 
+    with pytest.raises(
+        KeyError,
+        match="Cannot shuffle on 'z', as it is not in target DataFrame columns",
+    ):
         df.shuffle(["x", "z"])
+
 
 def test_shuffle_list_column_not_in_dataframe(df):
     # all cols in list are not in dataframe
-    with pytest.raises(KeyError,
-
-    match=r"Cannot shuffle on") as excinfo: 
+    with pytest.raises(KeyError, match=r"Cannot shuffle on") as excinfo:
         df.shuffle(["zz", "z"])
     assert "z" in str(excinfo.value)
     assert "zz" in str(excinfo.value)
 
+
 def test_shuffle_column_columns(df):
     df.shuffle(df.columns[-1])
+
 
 def test_shuffle_column_projection(df):
     df2 = df.shuffle("x")[["x"]].simplify()

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -130,6 +130,32 @@ def test_task_shuffle_index(npartitions, max_branch, pdf):
     assert sorted(df3.compute().values) == list(range(20))
 
 
+def test_shuffle_str_column_not_in_dataframe(df):
+    # ddf = from_pandas(pdf, npartitions=10)
+    with pytest.raises(KeyError, 
+    match="Cannot shuffle on 'z', as it is not in target DataFrame columns"
+    ):
+        df.shuffle(on="z")#.compute()
+
+def test_shuffle_mixed_list_column_not_in_dataframe(df):
+    # not all cols in list are not in dataframe
+    with pytest.raises(KeyError,
+    match= "Cannot shuffle on 'z', as it is not in target DataFrame columns"
+    ): 
+        df.shuffle(["x", "z"])
+
+def test_shuffle_list_column_not_in_dataframe(df):
+    # all cols in list are not in dataframe
+    with pytest.raises(KeyError,
+
+    match=r"Cannot shuffle on") as excinfo: 
+        df.shuffle(["zz", "z"])
+    assert "z" in str(excinfo.value)
+    assert "zz" in str(excinfo.value)
+
+def test_shuffle_column_columns(df):
+    df.shuffle(df.columns[-1])
+
 def test_shuffle_column_projection(df):
     df2 = df.shuffle("x")[["x"]].simplify()
 

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -131,12 +131,11 @@ def test_task_shuffle_index(npartitions, max_branch, pdf):
 
 
 def test_shuffle_str_column_not_in_dataframe(df):
-    # ddf = from_pandas(pdf, npartitions=10)
     with pytest.raises(
         KeyError,
         match="Cannot shuffle on",
     ) as execinfo:
-        df.shuffle(on="z")  # .compute()
+        df.shuffle(on="z")
     assert "z" in str(execinfo.value)
 
 


### PR DESCRIPTION
closes https://github.com/dask/dask/issues/11174

Handles shuffling on columns that do not exist. Raises a KeyError. 