### PR TITLE
Add unify-chunks draft to arrays

### DIFF
--- a/dask_expr/array/blockwise.py
+++ b/dask_expr/array/blockwise.py
@@ -1,15 +1,19 @@
 import functools
 import itertools
+import math
 import numbers
+import warnings
 from collections.abc import Iterable
 
 import numpy as np
 import toolz
 from dask.array.core import (
+    PerformanceWarning,
     _enforce_dtype,
     apply_infer_dtype,
+    broadcast_dimensions,
+    common_blockdim,
     normalize_arg,
-    unify_chunks,
 )
 from dask.array.utils import compute_meta
 from dask.base import is_dask_collection, tokenize
@@ -17,7 +21,7 @@ from dask.blockwise import blockwise as core_blockwise
 from dask.delayed import unpack_collections
 from dask.utils import cached_property, funcname
 
-from dask_expr.array.core import Array
+from dask_expr.array.core import Array, asarray
 
 
 class Blockwise(Array):
@@ -40,7 +44,7 @@ class Blockwise(Array):
         "dtype": None,
         "adjust_chunks": None,
         "new_axes": None,
-        "align_arrays": False,  # TODO: this should be true, future work
+        "align_arrays": True,
         "concatenate": None,
         "_meta_provided": None,
         "kwargs": None,
@@ -66,7 +70,7 @@ class Blockwise(Array):
     @functools.cached_property
     def chunks(self):
         if self.align_arrays:
-            chunkss, arrays = unify_chunks(*self.args)
+            chunkss, arrays, _ = unify_chunks(*self.args)
         else:
             arginds = [
                 (a, i) for (a, i) in toolz.partition(2, self.args) if i is not None
@@ -175,6 +179,12 @@ class Blockwise(Array):
         )
         return dict(graph)
 
+    def _simplify_down(self):
+        if self.align_arrays:
+            _, arrays, changed = unify_chunks(*self.args)
+            if changed:
+                return type(self)(*self.operands[: len(self._parameters)], *arrays)
+
 
 def blockwise(
     func,
@@ -185,7 +195,7 @@ def blockwise(
     dtype=None,
     adjust_chunks=None,
     new_axes=None,
-    align_arrays=False,  # TODO: this should be true, future work
+    align_arrays=True,
     concatenate=None,
     meta=None,
     cls=Blockwise,
@@ -343,8 +353,6 @@ def blockwise(
     if new:
         raise ValueError("Unknown dimension", new)
 
-    assert not align_arrays  # TODO, need unify_chunks
-
     return cls(
         func,
         out_ind,
@@ -353,7 +361,7 @@ def blockwise(
         dtype,
         adjust_chunks,
         new_axes,
-        align_arrays,  # TODO: this should be true, future work
+        align_arrays,
         concatenate,
         meta,
         kwargs,
@@ -367,7 +375,7 @@ class Elemwise(Blockwise):
         "dtype": None,
         "name": None,
     }
-    align_arrays = False
+    align_arrays = True
     new_axes = {}
     adjust_chunks = None
     token = None
@@ -608,7 +616,7 @@ def is_scalar_for_elemwise(arg):
 class Transpose(Blockwise):
     _parameters = ["array", "axes"]
     func = staticmethod(np.transpose)
-    align_arrays = False
+    align_arrays = True
     adjust_chunks = None
     concatenate = None
     token = "transpose"
@@ -647,3 +655,107 @@ class Transpose(Blockwise):
             return Transpose(self.array.array, axes)
         if self.axes == tuple(range(self.ndim)):
             return self.array
+
+
+def unify_chunks(*args, **kwargs):
+    """
+    Unify chunks across a sequence of arrays
+
+    This utility function is used within other common operations like
+    :func:`dask.array.core.map_blocks` and :func:`dask.array.core.blockwise`.
+    It is not commonly used by end-users directly.
+
+    Parameters
+    ----------
+    *args: sequence of Array, index pairs
+        Sequence like (x, 'ij', y, 'jk', z, 'i')
+
+    Examples
+    --------
+    >>> import dask.array as da
+    >>> x = da.ones(10, chunks=((5, 2, 3),))
+    >>> y = da.ones(10, chunks=((2, 3, 5),))
+    >>> chunkss, arrays = unify_chunks(x, 'i', y, 'i')
+    >>> chunkss
+    {'i': (2, 3, 2, 3)}
+
+    >>> x = da.ones((100, 10), chunks=(20, 5))
+    >>> y = da.ones((10, 100), chunks=(4, 50))
+    >>> chunkss, arrays = unify_chunks(x, 'ij', y, 'jk', 'constant', None)
+    >>> chunkss  # doctest: +SKIP
+    {'k': (50, 50), 'i': (20, 20, 20, 20, 20), 'j': (4, 1, 3, 2)}
+
+    >>> unify_chunks(0, None)
+    ({}, [0])
+
+    Returns
+    -------
+    chunkss : dict
+        Map like {index: chunks}.
+    arrays : list
+        List of rechunked arrays.
+
+    See Also
+    --------
+    common_blockdim
+    """
+    if not args:
+        return {}, []
+
+    arginds = [
+        # TODO
+        # (asanyarray(a) if ind is not None else a, ind) for a, ind in partition(2, args)
+        (asarray(a) if ind is not None else a, ind)
+        for a, ind in toolz.partition(2, args)
+    ]  # [x, ij, y, jk]
+    warn = kwargs.get("warn", True)
+
+    arrays, inds = zip(*arginds)
+    if all(ind is None for ind in inds):
+        return {}, list(arrays), False
+    if all(ind == inds[0] for ind in inds) and all(
+        a.chunks == arrays[0].chunks for a in arrays
+    ):
+        return dict(zip(inds[0], arrays[0].chunks)), arrays, False
+
+    nameinds = []
+    blockdim_dict = dict()
+    max_parts = 0
+    for a, ind in arginds:
+        if ind is not None:
+            nameinds.append((a.name, ind))
+            blockdim_dict[a.name] = a.chunks
+            max_parts = max(max_parts, a.npartitions)
+        else:
+            nameinds.append((a, ind))
+
+    chunkss = broadcast_dimensions(nameinds, blockdim_dict, consolidate=common_blockdim)
+    nparts = math.prod(map(len, chunkss.values()))
+
+    if warn and nparts and nparts >= max_parts * 10:
+        warnings.warn(
+            "Increasing number of chunks by factor of %d" % (nparts / max_parts),
+            PerformanceWarning,
+            stacklevel=3,
+        )
+
+    arrays = []
+    changed = False
+    for a, i in arginds:
+        if i is None:
+            arrays.append(a)
+        else:
+            chunks = tuple(
+                chunkss[j]
+                if a.shape[n] > 1
+                else a.shape[n]
+                if not np.isnan(sum(chunkss[j]))
+                else None
+                for n, j in enumerate(i)
+            )
+            if chunks != a.chunks and all(a.chunks):
+                arrays.append(a.rechunk(chunks))
+                changed = True
+            else:
+                arrays.append(a)
+    return chunkss, arrays, changed

--- a/dask_expr/array/blockwise.py
+++ b/dask_expr/array/blockwise.py
@@ -616,7 +616,7 @@ def is_scalar_for_elemwise(arg):
 class Transpose(Blockwise):
     _parameters = ["array", "axes"]
     func = staticmethod(np.transpose)
-    align_arrays = True
+    align_arrays = False
     adjust_chunks = None
     concatenate = None
     token = "transpose"
@@ -748,7 +748,7 @@ def unify_chunks(*args, **kwargs):
             chunks = tuple(
                 chunkss[j]
                 if a.shape[n] > 1
-                else a.shape[n]
+                else (a.shape[n],)
                 if not np.isnan(sum(chunkss[j]))
                 else None
                 for n, j in enumerate(i)

--- a/dask_expr/array/core.py
+++ b/dask_expr/array/core.py
@@ -56,8 +56,20 @@ class Array(core.Expr, DaskMethodsMixin):
     def __array_ufunc__(self, numpy_ufunc, method, *inputs, **kwargs):
         raise NotImplementedError()
 
-    def __array_function__(self, *args, **kwargs):
-        raise NotImplementedError()
+    def __array_function__(self, func, types, args, kwargs):
+        # TODO: look at dask.array implementation to find lots of other cases
+        import dask_expr.array as module
+
+        for submodule in func.__module__.split(".")[1:]:
+            try:
+                module = getattr(module, submodule)
+            except AttributeError:
+                # TODO
+                # return handle_nonmatching_names(func, args, kwargs)
+                raise
+
+        da_func = getattr(module, func.__name__)
+        return da_func(*args, **kwargs)
 
     def __array__(self):
         return self.compute()

--- a/dask_expr/array/core.py
+++ b/dask_expr/array/core.py
@@ -115,10 +115,11 @@ class Array(core.Expr, DaskMethodsMixin):
         return dtype
 
     def __dask_keys__(self):
+        out = self.lower_completely()
         if self._cached_keys is not None:
             return self._cached_keys
 
-        name, chunks, numblocks = self.name, self.chunks, self.numblocks
+        name, chunks, numblocks = out.name, out.chunks, out.numblocks
 
         def keys(*args):
             if not chunks:
@@ -160,6 +161,9 @@ class Array(core.Expr, DaskMethodsMixin):
         method=None,
     ):
         from dask_expr.array.rechunk import Rechunk
+
+        if isinstance(chunks, tuple):
+            assert len(chunks) == self.ndim
 
         return Rechunk(self, chunks, threshold, block_size_limit, balance, method)
 

--- a/dask_expr/array/slicing.py
+++ b/dask_expr/array/slicing.py
@@ -32,7 +32,10 @@ class Slice(Array):
         return self._info[1]
 
     def _simplify_down(self):
-        if all(idx == slice(None, None, None) for idx in self.index):
+        if all(
+            isinstance(idx, slice) and idx == slice(None, None, None)
+            for idx in self.index
+        ):
             return self.array
         if isinstance(self.array, Slice):
             return Slice(

--- a/dask_expr/array/tests/test_array.py
+++ b/dask_expr/array/tests/test_array.py
@@ -218,3 +218,12 @@ def test_unify_chunks():
     bb = da.asarray(b, chunks=(10,))
 
     assert_eq(a + b, aa + bb)
+
+
+def test_array_function():
+    a = np.random.random((10, 20))
+    aa = da.asarray(a, chunks=(4, 5))
+
+    assert isinstance(np.nanmean(aa), da.Array)
+
+    assert_eq(np.nanmean(aa), np.nanmean(a))

--- a/dask_expr/array/tests/test_array.py
+++ b/dask_expr/array/tests/test_array.py
@@ -209,3 +209,12 @@ def test_asarray():
     b = da.asarray(a)
     assert_eq(a, b)
     assert isinstance(b, da.Array) and type(b) == type(da.from_array(a))
+
+
+def test_unify_chunks():
+    a = np.random.random((10, 20))
+    aa = da.asarray(a, chunks=(4, 5))
+    b = np.random.random((20,))
+    bb = da.asarray(b, chunks=(10,))
+
+    assert_eq(a + b, aa + bb)


### PR DESCRIPTION
This makes this less broken (but not necessarily entirely not broken)

```python
import dask_expr.array as da

x = da.random.random((10, 10), chunks=(8, 8))
y = da.random.random((10, 10), chunks=(5, 5))

z = x + y
```

```python
z.pprint()
```
```
Elemwise: op=<built-in function add>
  Random: rng=<dask_expr.array.random.RandomState object at 0x120599a90> distribution='random_sample' size=(10, 10) chunks=(8, 8) args=() kwargs={}
  Random: rng=<dask_expr.array.random.RandomState object at 0x120599a90> distribution='random_sample' size=(10, 10) chunks=(5, 5) args=() kwargs={}
```

```python
z.simplify().pprint()
```
```
Elemwise: op=<built-in function add>
  Random: rng=<dask_expr.array.random.RandomState object at 0x120599a90> distribution='random_sample' size=(10, 10) chunks=((5, 3, 2), (5, 3, 2)) args=() kwargs={}
  Random: rng=<dask_expr.array.random.RandomState object at 0x120599a90> distribution='random_sample' size=(10, 10) chunks=((5, 3, 2), (5, 3, 2)) args=() kwargs={}
```


This required a small change to `dask.array.utils.assert_eq`

```diff
diff --git a/dask/array/utils.py b/dask/array/utils.py
index 9fe33f91c..ee4ed6f95 100644
--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -202,8 +202,13 @@ def _not_empty(x):
     return x.shape and 0 not in x.shape


-def _check_dsk(dsk):
+def _check_dsk(x):
     """Check that graph is well named and non-overlapping"""
+    if hasattr(x, "simplify"):
+        x = x.simplify()
+
+    dsk = x.dask
+
     if not isinstance(dsk, HighLevelGraph):
         return

@@ -268,7 +273,7 @@ def _get_dt_meta_computed(
         assert x.dtype is not None
         adt = x.dtype
         if check_graph:
-            _check_dsk(x.dask)
+            _check_dsk(x)
         x_meta = getattr(x, "_meta", None)
         if check_chunks:
             # Replace x with persisted version to avoid computing it twice.
```