### PR TITLE
Skip test if optional xarray cannot be imported

### DIFF
--- a/dask_expr/array/tests/test_array.py
+++ b/dask_expr/array/tests/test_array.py
@@ -131,6 +131,8 @@ def test_slicing_optimization_change_dimensionality():
 
 
 def test_xarray():
+    pytest.importorskip("xarray")
+
     import xarray as xr
 
     a = np.random.random((10, 20))


### PR DESCRIPTION
Fix #1102
