### PR TITLE
Register `read_parquet` and `read_csv` as "dispatchable"

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -5106,7 +5106,6 @@ def read_csv(
     header="infer",
     dtype_backend=None,
     storage_options=None,
-    _legacy_dataframe_backend="pandas",
     **kwargs,
 ):
     from dask_expr.io.csv import ReadCSV
@@ -5120,7 +5119,7 @@ def read_csv(
             storage_options=storage_options,
             kwargs=kwargs,
             header=header,
-            dataframe_backend=_legacy_dataframe_backend,
+            dataframe_backend="pandas",
         )
     )
 

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -14,7 +14,7 @@ import dask.dataframe.methods as methods
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-from dask import compute, config, get_annotations
+from dask import compute, get_annotations
 from dask.array import Array
 from dask.base import DaskMethodsMixin, is_dask_collection, named_schedulers
 from dask.core import flatten
@@ -5106,7 +5106,7 @@ def read_csv(
     header="infer",
     dtype_backend=None,
     storage_options=None,
-    _legacy_backend="pandas",
+    _legacy_dataframe_backend="pandas",
     **kwargs,
 ):
     from dask_expr.io.csv import ReadCSV
@@ -5120,7 +5120,7 @@ def read_csv(
             storage_options=storage_options,
             kwargs=kwargs,
             header=header,
-            dataframe_backend=_legacy_backend,
+            dataframe_backend=_legacy_dataframe_backend,
         )
     )
 

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -5099,17 +5099,18 @@ def from_dask_array(x, columns=None, index=None, meta=None):
     return from_legacy_dataframe(df, optimize=True)
 
 
+@dataframe_creation_dispatch.register_inplace("pandas")
 def read_csv(
     path,
     *args,
     header="infer",
     dtype_backend=None,
     storage_options=None,
+    _legacy_backend="pandas",
     **kwargs,
 ):
     from dask_expr.io.csv import ReadCSV
 
-    dataframe_backend = config.get("dataframe.backend", "pandas")
     if not isinstance(path, str):
         path = stringify_path(path)
     return new_collection(
@@ -5119,7 +5120,7 @@ def read_csv(
             storage_options=storage_options,
             kwargs=kwargs,
             header=header,
-            dataframe_backend=dataframe_backend,
+            dataframe_backend=_legacy_backend,
         )
     )
 
@@ -5174,6 +5175,7 @@ def read_fwf(
     )
 
 
+@dataframe_creation_dispatch.register_inplace("pandas")
 def read_parquet(
     path=None,
     columns=None,


### PR DESCRIPTION
Registers  the `read_parquet` and `read_csv` definitions in dask-expr for the `"pandas"` backend.

**Some Notes**:
- I am doing this now, while RAPIDS is temporarily pinned to dask-2024.7.1 anyway
- I don't have specific plans to register anything "fancy" for the `"cudf"` backend right away. However, it probably makes sense to move away from the parquet `Engine` approach eventually (it probably makes more sense to lean into the `Expr` class structure to implement backend-specific logic). 