### PR TITLE
Introduce `ToBackend` expression

### DIFF
--- a/dask_expr/_backends.py
+++ b/dask_expr/_backends.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from dask.backends import CreationDispatch
 from dask.dataframe.backends import DataFrameBackendEntrypoint
+from dask.dataframe.dispatch import to_pandas_dispatch
 
 from dask_expr._dispatch import get_collection_type
 from dask_expr._expr import ToBackend
@@ -36,8 +37,6 @@ dataframe_creation_dispatch = CreationDispatch(
 class ToPandasBackend(ToBackend):
     @staticmethod
     def operation(df, options):
-        from dask.dataframe.dispatch import to_pandas_dispatch
-
         return to_pandas_dispatch(df, **options)
 
     def _simplify_down(self):

--- a/dask_expr/_backends.py
+++ b/dask_expr/_backends.py
@@ -5,7 +5,6 @@ import pandas as pd
 from dask.backends import CreationDispatch
 from dask.dataframe.backends import DataFrameBackendEntrypoint
 
-from dask_expr._collection import new_collection
 from dask_expr._dispatch import get_collection_type
 from dask_expr._expr import ToBackend
 
@@ -41,6 +40,11 @@ class ToPandasBackend(ToBackend):
 
         return to_pandas_dispatch(df, **options)
 
+    def _simplify_down(self):
+        if isinstance(self.frame._meta, (pd.DataFrame, pd.Series, pd.Index)):
+            # We already have pandas data
+            return self.frame
+
 
 class PandasBackendEntrypoint(DataFrameBackendEntrypoint):
     """Pandas-Backend Entrypoint Class for Dask-Expressions
@@ -50,19 +54,10 @@ class PandasBackendEntrypoint(DataFrameBackendEntrypoint):
     """
 
     @classmethod
-    def to_backend_dispatch(cls):
-        from dask.dataframe.dispatch import to_pandas_dispatch
-
-        return to_pandas_dispatch
-
-    @classmethod
     def to_backend(cls, data, **kwargs):
-        if isinstance(data._meta, (pd.DataFrame, pd.Series, pd.Index)):
-            # Already a pandas-backed collection
-            return data
-        return new_collection(
-            ToPandasBackend(data, kwargs)
-        )  # data.map_partitions(cls.to_backend_dispatch(), **kwargs)
+        from dask_expr._collection import new_collection
+
+        return new_collection(ToPandasBackend(data, kwargs))
 
 
 dataframe_creation_dispatch.register_backend("pandas", PandasBackendEntrypoint())

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1304,7 +1304,6 @@ class _DeepCopy(Elemwise):
 
 
 class ToBackend(Elemwise):
-    operation = None
     _parameters = ["frame", "options"]
     _projection_passthrough = True
     _filter_passthrough = True

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1303,6 +1303,17 @@ class _DeepCopy(Elemwise):
         return df.copy(deep=True)
 
 
+class ToBackend(Elemwise):
+    _parameters = ["frame", "options"]
+    _projection_passthrough = True
+    _filter_passthrough = True
+    _preserves_partitioning_information = True
+
+    @staticmethod
+    def operation(df, options):
+        raise NotImplementedError()
+
+
 class RenameSeries(Elemwise):
     _parameters = ["frame", "index", "sorted_index"]
     _defaults = {"sorted_index": False}

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1304,14 +1304,11 @@ class _DeepCopy(Elemwise):
 
 
 class ToBackend(Elemwise):
+    operation = None
     _parameters = ["frame", "options"]
     _projection_passthrough = True
     _filter_passthrough = True
     _preserves_partitioning_information = True
-
-    @staticmethod
-    def operation(df, options):
-        raise NotImplementedError()
 
 
 class RenameSeries(Elemwise):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -2665,3 +2665,12 @@ def test_empty_from_pandas_projection():
     df["foo"] = from_pandas(foo, npartitions=1)
     pdf["foo"] = foo
     assert_eq(df["foo"], pdf["foo"])
+
+
+def test_to_backend_simplify():
+    with dask.config.set({"dataframe.backend": "pandas"}):
+        df = from_dict({"x": [1, 2, 3], "y": [4, 5, 6]}, npartitions=2)
+        df2 = df.to_backend("pandas")[["y"]]
+        assert str(df2.expr) != str(df[["y"]].expr)
+        df3 = df2.simplify()
+        assert str(df3.expr) == str(df[["y"]].expr)


### PR DESCRIPTION
Introduces a simple `ToBackend` (and `ToPandasBackend` implementation).

The current approach of using `map_partitions` in `PandasBackendEntrypoint` effectively blocks query-planning optimizations when data is moved between GPU and CPU. The obvious solution is to use a simple `Expr` class.