### PR TITLE
[WIP][POC] Add ``ResourceBarrier`` expression to change resources within an expression graph

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -445,7 +445,11 @@ Expr={expr}"""
 
     def persist(self, fuse=True, **kwargs):
         out = self.optimize(fuse=fuse)
-        return DaskMethodsMixin.persist(out, **kwargs)
+        return DaskMethodsMixin.persist(
+            out,
+            task_resources=out.expr.collect_task_resources(),
+            **kwargs,
+        )
 
     def compute(self, fuse=True, **kwargs):
         """Compute this DataFrame.

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -474,7 +474,11 @@ Expr={expr}"""
         if not isinstance(out, Scalar):
             out = out.repartition(npartitions=1)
         out = out.optimize(fuse=fuse)
-        return DaskMethodsMixin.compute(out, **kwargs)
+        return DaskMethodsMixin.compute(
+            out,
+            task_resources=out.expr.collect_task_resources(),
+            **kwargs,
+        )
 
     def analyze(self, filename: str | None = None, format: str | None = None) -> None:
         """Outputs statistics about every node in the expression.
@@ -2493,6 +2497,9 @@ Expr={expr}"""
         dask_expr.from_delayed
         """
         return self.to_legacy_dataframe().to_delayed(optimize_graph=optimize_graph)
+
+    def resource_barrier(self, resources):
+        return new_collection(expr.ResourceBarrier(self.expr, resources))
 
     def to_backend(self, backend: str | None = None, **kwargs):
         """Move to a new DataFrame backend

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1303,6 +1303,23 @@ class _DeepCopy(Elemwise):
         return df.copy(deep=True)
 
 
+class ResourceBarrier(Elemwise):
+    _parameters = ["frame", "resources"]
+    _projection_passthrough = True
+    _filter_passthrough = True
+    _preserves_partitioning_information = True
+
+    def _task(self, index: int):
+        return (self.frame._name, index)
+
+    @property
+    def _meta(self):
+        return self.frame._meta
+
+    def _divisions(self):
+        return self.frame.divisions
+
+
 class RenameSeries(Elemwise):
     _parameters = ["frame", "index", "sorted_index"]
     _defaults = {"sorted_index": False}
@@ -3128,7 +3145,7 @@ def are_co_aligned(*exprs):
 
 def is_valid_blockwise_op(expr):
     return isinstance(expr, Blockwise) and not isinstance(
-        expr, (FromPandas, FromArray, FromDelayed)
+        expr, (FromPandas, FromArray, FromDelayed, ResourceBarrier)
     )
 
 


### PR DESCRIPTION
- Related to the discussion in https://github.com/dask/dask/issues/10937
- Depends distributed changes (https://github.com/rjzamora/distributed/tree/resource_barrier)

### General Proposal

We should make it possible to define explicit resource barriers within a query. For example:

```python
# IO phase: Use cpu workers
df = dd.read_parquet("s3://my-bucket/my-dataset").resource_barrier({'CPU': 1})

# Compute phase: Convert to cudf and use GPU
# (Only using mean as a simple example)
df.to_backend("cudf").mean().resource_barrier({'GPU': 1})
```

In this case, calling `resource_barrier` will add an explicit `ResourceBarrier` expression to the expression graph. Then, when `persist`/`compute` is called, the corresponding resource requirement will be attached to all expressions before that point (stopping only at other `ResourceBarrier` expressions). This makes it possible to add arbitrary resource barriers within a query without adding any special resource/annotation code to any `Expr` classes.

The underlying `ResourceBarrier` expression also allows column-projection and filter operations to pass through without preventing the final resource annotations from being "optimized away."