### PR TITLE
Avoid calling ``array`` attribute on ``cudf.Series``

### DIFF
--- a/dask_expr/_describe.py
+++ b/dask_expr/_describe.py
@@ -51,11 +51,16 @@ class DescribeNumeric(Reduction):
             SeriesQuantile(frame, q=percentiles, method=self.percentile_method),
             frame.max(split_every=self.split_every),
         ]
+        try:
+            unit = getattr(self.frame._meta.array, "unit", None)
+        except AttributeError:
+            # cudf Series has no array attribute
+            unit = None
         return DescribeNumericAggregate(
             self.frame._meta.name,
             is_td_col,
             is_dt_col,
-            getattr(self.frame._meta.array, "unit", None),
+            unit,
             *stats,
         )
 


### PR DESCRIPTION
RAPIDS is currently pinned to 2024.7.1 until [Python-3.9 support is removed](https://github.com/rapidsai/build-planning/issues/88) (hopefully soon). When the pin is removed, `describe` will not work with the "cudf" backend unless we avoid calling `*.array` on a `cudf.Series`.

Note that the minor/breaking change was added in https://github.com/dask/dask-expr/pull/1111