### PR TITLE
Improve performance of `DelayedsExpr` through caching

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2986,7 +2986,7 @@ class DelayedsExpr(Expr):
     def __str__(self):
         return f"{type(self).__name__}({str(self.operands[0])})"
 
-    @property
+    @functools.cached_property
     def _name(self):
         return "delayed-container-" + _tokenize_deterministic(*self.operands)
 


### PR DESCRIPTION
This PR fixes a (quadratic?) performance issue and reduces the runtime of 

```python
import dask.dataframe as dd
import dask
import pandas as pd

def construct(num):
    return pd.DataFrame({"x": [num] * 100})

delayed_frames = [dask.delayed(construct)(i) for i in range(4000)]
x = dd.from_delayed(delayed_frames).to_delayed()
```
from 47s to <400ms