### PR TITLE
[WIP] Support ``blocksize`` and ``aggregate_files`` options in ``ReadParquetPyarrowFS``

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -5428,13 +5428,14 @@ def read_parquet(
             raise NotImplementedError(
                 "split_row_groups is not supported when using the pyarrow filesystem."
             )
-        if blocksize is not None and blocksize != "default":
+        if blocksize is not None and blocksize != "default" and calculate_divisions:
             raise NotImplementedError(
-                "blocksize is not supported when using the pyarrow filesystem."
+                "blocksize is not supported when using the pyarrow filesystem "
+                "if calculate_divisions is set to True."
             )
-        if aggregate_files is not None:
+        if aggregate_files not in (None, True, False):
             raise NotImplementedError(
-                "aggregate_files is not supported when using the pyarrow filesystem."
+                "aggregate_files must be bool or None when using the pyarrow filesystem."
             )
         if parquet_file_extension != (".parq", ".parquet", ".pq"):
             raise NotImplementedError(
@@ -5459,6 +5460,8 @@ def read_parquet(
                 arrow_to_pandas=arrow_to_pandas,
                 pyarrow_strings_enabled=pyarrow_strings_enabled(),
                 kwargs=kwargs,
+                blocksize=blocksize,
+                aggregate_files=aggregate_files,
                 _series=isinstance(columns, str),
             )
         )

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -5209,12 +5209,15 @@ def read_parquet(
     .. note::
         Dask automatically resizes partitions to ensure that each partition is of
         adequate size. The optimizer uses the ratio of selected columns to total
-        columns to squash multiple files into one partition.
+        columns to squash multiple files into one partition. If the ``blocksize``
+        argument is specified,
 
         Additionally, the Optimizer uses a minimum size per partition (default 75MB)
         to avoid too many small partitions. This configuration can be set with
 
         >>> dask.config.set({"dataframe.parquet.minimum-partition-size": "100MB"})
+
+        To disable file aggregation, set ``aggregate_files=False`` explicitly.
 
     .. note::
         Specifying ``filesystem="arrow"`` leverages a complete reimplementation of
@@ -5313,9 +5316,20 @@ def read_parquet(
         set the default value of ``split_row_groups`` (using row-group metadata
         from a single file), and will be ignored if ``split_row_groups`` is not
         set to 'infer' or 'adaptive'. Default is 256 MiB.
+
+        .. note::
+          If ``filesystem="arrow"`` is specified, the ``blocksize`` value will
+          be used to split files at optimization time, and the default will
+          be ``None``.
+
     aggregate_files : bool or str, default None
         WARNING: Passing a string argument to ``aggregate_files`` will result
         in experimental behavior. This behavior may change in the future.
+
+        .. note::
+          If ``filesystem="arrow"`` is specified, ``aggregate_files`` will be
+          ``True`` by default, and file aggregation will occur at optimization
+          time only.
 
         Whether distinct file paths may be aggregated into the same output
         partition. This parameter is only used when `split_row_groups` is set to

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -5428,7 +5428,7 @@ def read_parquet(
             raise NotImplementedError(
                 "split_row_groups is not supported when using the pyarrow filesystem."
             )
-        if blocksize is not None and blocksize != "default" and calculate_divisions:
+        if blocksize not in (None, "default") and calculate_divisions:
             raise NotImplementedError(
                 "blocksize is not supported when using the pyarrow filesystem "
                 "if calculate_divisions is set to True."

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -865,7 +865,7 @@ class ReadParquetPyarrowFS(ReadParquet):
     def _blocksize(self):
         if self.blocksize == "default":
             return None
-        return self.blocksize
+        return parse_bytes(self.blocksize)
 
     @property
     def _aggregate_files(self):
@@ -1187,7 +1187,7 @@ class ReadParquetPyarrowFS(ReadParquet):
             if col["path_in_schema"] in col_op:
                 after_projection += col["total_uncompressed_size"]
 
-        max_size = parse_bytes(self._blocksize)
+        max_size = self._blocksize
         max_splits = max(math.floor(approx_stats["num_row_groups"]), 1)
         if after_projection <= max_size:
             return 1

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -814,6 +814,11 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             len(_convert_to_list(self.operand("columns"))) / nr_original_columns, 0.001
         )
 
+    def _tune_up(self, parent):
+        if self.aggregate_files is False:
+            return
+        return super()._tune_up(parent)
+
 
 class ReadParquetPyarrowFS(ReadParquet):
     _parameters = [
@@ -1115,7 +1120,7 @@ class ReadParquetPyarrowFS(ReadParquet):
             if isinstance(parent, SplitParquetIO):
                 return
             return parent.substitute(self, SplitParquetIO(self))
-        if not self._aggregate_files:
+        if self._aggregate_files is False:
             return
         if self._fusion_compression_factor >= 1:
             return

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import itertools
+import math
 import operator
 import os
 import pickle
@@ -60,7 +61,7 @@ from dask_expr._expr import (
 from dask_expr._reductions import Len
 from dask_expr._util import _convert_to_list, _tokenize_deterministic
 from dask_expr.io import BlockwiseIO, PartitionsFiltered
-from dask_expr.io.io import FusedParquetIO
+from dask_expr.io.io import FusedParquetIO, SplitParquetIO
 
 
 @normalize_token.register(pa.fs.FileInfo)
@@ -831,6 +832,7 @@ class ReadParquetPyarrowFS(ReadParquet):
         "_partitions",
         "_series",
         "_dataset_info_cache",
+        "_blocksize",
     ]
     _defaults = {
         "columns": None,
@@ -847,6 +849,7 @@ class ReadParquetPyarrowFS(ReadParquet):
         "_partitions": None,
         "_series": False,
         "_dataset_info_cache": None,
+        "_blocksize": "256MiB",
     }
     _absorb_projections = True
     _filter_passthrough = True
@@ -1037,6 +1040,7 @@ class ReadParquetPyarrowFS(ReadParquet):
                 dataset_info["using_metadata_file"] = True
                 dataset_info["fragments"] = _frags = list(dataset.get_fragments())
                 dataset_info["file_sizes"] = [None for fi in _frags]
+                dataset_info["all_files"] = all_files
 
         if checksum is None:
             checksum = tokenize(all_files)
@@ -1094,7 +1098,11 @@ class ReadParquetPyarrowFS(ReadParquet):
         return self._division_from_stats[0]
 
     def _tune_up(self, parent):
-        if self._fusion_compression_factor >= 1:
+        if self._blocksize is not None and self._split_division_factor > 1:
+            if isinstance(parent, SplitParquetIO):
+                return
+            return parent.substitute(self, SplitParquetIO(self))
+        if not self._aggregate_files or self._fusion_compression_factor >= 1:
             return
         if isinstance(parent, FusedParquetIO):
             return
@@ -1150,6 +1158,22 @@ class ReadParquetPyarrowFS(ReadParquet):
         total_uncompressed = max(total_uncompressed, min_size)
         return max(after_projection / total_uncompressed, 0.001)
 
+    @property
+    def _split_division_factor(self) -> int:
+        approx_stats = self.approx_statistics()
+        after_projection = 0
+        col_op = self.operand("columns") or self.columns
+        for col in approx_stats["columns"]:
+            if col["path_in_schema"] in col_op:
+                after_projection += col["total_uncompressed_size"]
+
+        max_size = parse_bytes(self._blocksize)
+        max_splits = max(math.floor(approx_stats["num_row_groups"]), 1)
+        if after_projection <= max_size:
+            return 1
+        else:
+            return min(math.ceil(after_projection / max_size), max_splits)
+
     def _filtered_task(self, index: int):
         columns = self.columns.copy()
         index_name = self.index.name
@@ -1174,6 +1198,35 @@ class ReadParquetPyarrowFS(ReadParquet):
             self.kwargs.get("dtype_backend"),
             self.pyarrow_strings_enabled,
         )
+
+    @classmethod
+    def _partial_fragment_to_table(
+        cls,
+        fragment_wrapper,
+        local_split_index,
+        local_split_count,
+        filters,
+        columns,
+        schema,
+    ):
+        if isinstance(fragment_wrapper, FragmentWrapper):
+            fragment = fragment_wrapper.fragment
+        else:
+            fragment = fragment_wrapper
+
+        num_row_groups = fragment.num_row_groups
+        stride = max(math.floor(num_row_groups / local_split_count), 1)
+        offset = local_split_index * stride
+        row_groups = list(range(offset, min(offset + stride, num_row_groups)))
+        assert row_groups  # TODO: Handle empty partition case
+        fragment = fragment.format.make_fragment(
+            fragment.path,
+            fragment.filesystem,
+            fragment.partition_expression,
+            row_groups=row_groups,
+        )
+
+        return cls._fragment_to_table(fragment, filters, columns, schema)
 
     @staticmethod
     def _fragment_to_table(fragment_wrapper, filters, columns, schema):

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -1172,19 +1172,11 @@ class ReadParquetPyarrowFS(ReadParquet):
             if col["path_in_schema"] in col_op:
                 after_projection += col["total_uncompressed_size"]
 
-        min_size = parse_bytes(
+        target_size = self._blocksize or parse_bytes(
             dask.config.get("dataframe.parquet.minimum-partition-size")
         )
-        if self._blocksize:
-            # Use blocksize to calculate the compression factor
-            blocksize = max(parse_bytes(self._blocksize), min_size)
-            ratio = after_projection / blocksize
-        else:
-            # Aggregate files to preserve un-projected partition size
-            total_uncompressed = max(total_uncompressed, min_size)
-            ratio = after_projection / total_uncompressed
-
-        return max(ratio, 0.001)
+        total_uncompressed = max(total_uncompressed, target_size)
+        return max(after_projection / total_uncompressed, 0.001)
 
     @property
     def _split_division_factor(self) -> int:


### PR DESCRIPTION
**Proposed Changes**

Adds optimization-time ("tune up") support for `blocksize` and `aggregate_files` in `ReadParquetPyarrowFS`.

I like how dask-expr currently "squashes" small files together at optimization time. This PR simply expands the functionality of `_tune_up` to:

1. Split (rather than fuse) oversized parquet files (when `blocksize` is provided; Default is `None` for now).
2. Enable/disable small-file fusion with the `aggregate_files` argument (default to `True` when `filesystem="arrow"`).

**Note on (1)**: This is definitely a **much** higher priority than (2).

**Note on (2)**: `ReadParquetPyarrowFS` already "aggregates" files by default to avoid small partitions. It seems pretty natural to extend this functionality to target a specific `blocksize` value when one is specified. I do think `aggregate_files` is  an intuitive way to enable/disable the "squashing" of small files at optimization time, but I'm okay with leaving this out in favor of the `"dataframe.parquet.minimum-partition-size"` config. With that said, I do think `blocksize` should take precedence over that config value.

**Background**

The legacy `read_parquet` infrastructure is obviously a mess, and I'd like to avoid the need to keep maintaining it (in both dask and rapids). The logic in `ReadParquetPyarrowFS` is slightly arrow-specific, but is already very close to what I was already planning to do in rapids. The only missing feature that is preventing it from supporting real-world use cases is the lack of support for splitting oversized files (a need we definitely run into a lot in the wild).