### PR TITLE
Explicitly list setuptools as a build dependency in conda recipe

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - dask-core {{ dask_version }}
     - versioneer =0.28
     - setuptools >=62.6
-    - tomli
+    - tomli # [py<311]
   run:
     - python >=3.10
     - {{ pin_compatible('dask-core', max_pin='x.x.x.x') }}

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - pip
     - dask-core {{ dask_version }}
     - versioneer =0.28
+    - setuptools >=62.6
     - tomli
   run:
     - python >=3.10


### PR DESCRIPTION
With Python 3.13, `setuptools` has been removed as a default dependency of `pip` on conda-forge, with the encouraged advice to explicitly list this dependency in the build/host section:

https://conda-forge.org/news/2024/08/21/sunsetting-pip-deps/