### PR TITLE
Migrate Blockwise to use taskspec

### DIFF
--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -12,6 +12,7 @@ from dask.dataframe.multi import (
     merge_chunk,
 )
 from dask.dataframe.shuffle import partitioning_index
+from dask.typing import Key
 from dask.utils import apply, get_default_shuffle_method
 from toolz import merge_sorted, unique
 
@@ -923,17 +924,15 @@ class BlockwiseMerge(Merge, Blockwise):
     def _broadcast_dep(self, dep: Expr):
         return dep.npartitions == 1
 
-    def _task(self, index: int):
+    def _task(self, name: Key, index: int) -> Task:
         kwargs = self.kwargs.copy()
         kwargs["result_meta"] = self._meta
-        return (
-            apply,
+        return Task(
+            name,
             merge_chunk,
-            [
-                self._blockwise_arg(self.left, index),
-                self._blockwise_arg(self.right, index),
-            ],
-            kwargs,
+            self._blockwise_arg(self.left, index),
+            self._blockwise_arg(self.right, index),
+            **kwargs,
         )
 
 

--- a/dask_expr/datasets.py
+++ b/dask_expr/datasets.py
@@ -3,7 +3,9 @@ import operator
 
 import numpy as np
 import pandas as pd
+from dask._task_spec import Task
 from dask.dataframe.utils import pyarrow_strings_enabled
+from dask.typing import Key
 
 from dask_expr._collection import new_collection
 from dask_expr._expr import ArrowStringConversion
@@ -74,17 +76,18 @@ class Timeseries(PartitionsFiltered, BlockwiseIO):
             self.kwargs,
         )
 
-    def _filtered_task(self, index):
+    def _filtered_task(self, name: Key, index: int) -> Task:
         full_divisions = self._divisions()
         ndtypes = max(len(self.operand("dtypes")), 1)
-        task = (
+        task = Task(
+            name,
             self._make_timeseries_part,
             full_divisions[index],
             full_divisions[index + 1],
             self.random_state[index * ndtypes],
         )
         if self._series:
-            return (operator.getitem, task, self.operand("columns")[0])
+            return Task(name, operator.getitem, task, self.operand("columns")[0])
         return task
 
 

--- a/dask_expr/io/csv.py
+++ b/dask_expr/io/csv.py
@@ -1,6 +1,9 @@
 import functools
 import operator
 
+from dask._task_spec import Task
+from dask.typing import Key
+
 from dask_expr._expr import Projection
 from dask_expr._util import _convert_to_list
 from dask_expr.io.io import BlockwiseIO, PartitionsFiltered
@@ -117,11 +120,13 @@ class ReadCSV(PartitionsFiltered, BlockwiseIO):
 
     @functools.cached_property
     def _tasks(self):
-        return list(self._ddf.dask.to_dict().values())
+        from dask._task_spec import convert_legacy_graph
 
-    def _filtered_task(self, index: int):
+        return list(convert_legacy_graph(self._ddf.dask.to_dict()).values())
+
+    def _filtered_task(self, name: Key, index: int) -> Task:
         if self._series:
-            return (operator.getitem, self._tasks[index], self.columns[0])
+            return Task(name, operator.getitem, self._tasks[index], self.columns[0])
         return self._tasks[index]
 
 

--- a/dask_expr/io/tests/test_distributed.py
+++ b/dask_expr/io/tests/test_distributed.py
@@ -35,7 +35,7 @@ def test_io_fusion_merge(tmpdir):
     pdf = pd.DataFrame({c: range(100) for c in "abcdefghij"})
     with LocalCluster(processes=False, n_workers=2) as cluster:
         with Client(cluster) as client:  # noqa: F841
-            dx.from_pandas(pdf, 10).to_parquet(tmpdir)
+            dx.from_pandas(pdf, 2).to_parquet(tmpdir)
 
             df = dx.read_parquet(tmpdir).merge(
                 dx.read_parquet(tmpdir).add_suffix("_x"), left_on="a", right_on="a_x"
@@ -63,4 +63,4 @@ def test_pickle_size(tmpdir, filesystem):
     df = read_parquet(tmpdir, filesystem=filesystem)
     from distributed.protocol import dumps
 
-    assert len(b"".join(dumps(df.optimize().dask))) <= 8300
+    assert len(b"".join(dumps(df.optimize().dask))) <= 9581

--- a/dask_expr/io/tests/test_distributed.py
+++ b/dask_expr/io/tests/test_distributed.py
@@ -63,4 +63,4 @@ def test_pickle_size(tmpdir, filesystem):
     df = read_parquet(tmpdir, filesystem=filesystem)
     from distributed.protocol import dumps
 
-    assert len(b"".join(dumps(df.optimize().dask))) <= 9581
+    assert len(b"".join(dumps(df.optimize().dask))) <= 9000

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1595,13 +1595,6 @@ def test_random_partitions(df, pdf):
     assert b.ndim == 1
 
 
-def test_simple_graphs(df):
-    expr = (df + 1).expr
-    graph = expr.__dask_graph__()
-
-    assert graph[(expr._name, 0)] == (operator.add, (df.expr._name, 0), 1)
-
-
 def test_values():
     from dask.array.utils import assert_eq
 


### PR DESCRIPTION
This is migrating the blockwise expressions and connected ones to the new task spec.

I ran into interesting issues while ripping out the recursion in https://github.com/dask/dask-expr/pull/1158 and wanted to do this step here first.