### PR TITLE
Use Taskspec fuse implementation

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -3776,11 +3776,15 @@ class Fused(Blockwise):
 
             assert t.key == subname
             internal_tasks[t.key] = t
+        # The above is ambiguous and we have to cull to get an unambiguous graph
         outkey = (self.exprs[0]._name, index)
         work = [outkey]
         internal_tasks_culled = []
         while work:
             tkey = work.pop()
+            if tkey not in internal_tasks:
+                # External dependency
+                continue
             t = internal_tasks[tkey]
             internal_tasks_culled.append(t)
             work.extend(t.dependencies)

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -3766,32 +3766,25 @@ class Fused(Blockwise):
         return dep.npartitions == 1
 
     def _task(self, name: Key, index: int) -> Task:
-        internal_tasks = []
-        seen_keys = set()
-        external_deps = set()
+        internal_tasks = {}
         for _expr in self.exprs:
             if self._broadcast_dep(_expr):
                 subname = (_expr._name, 0)
             else:
                 subname = (_expr._name, index)
             t = _expr._task(subname, subname[1])
+
             assert t.key == subname
-            internal_tasks.append(t)
-            seen_keys.add(subname)
-            external_deps.update(t.dependencies)
-        external_deps -= seen_keys
-        dependencies = {dep: TaskRef(dep) for dep in external_deps}
-        t = Task(
-            name,
-            Fused._execute_internal_graph,
-            # Wrap the actual subgraph as a data node such that the tasks are
-            # not erroneously parsed. The external task would otherwise carry
-            # the internal keys as dependencies which is not satisfiable
-            DataNode(None, internal_tasks),
-            dependencies,
-            (self.exprs[0]._name, index),
-        )
-        return t
+            internal_tasks[t.key] = t
+        outkey = (self.exprs[0]._name, index)
+        work = [outkey]
+        internal_tasks_culled = []
+        while work:
+            tkey = work.pop()
+            t = internal_tasks[tkey]
+            internal_tasks_culled.append(t)
+            work.extend(t.dependencies)
+        return Task.fuse(*internal_tasks_culled, key=name)
 
     @staticmethod
     def _execute_internal_graph(internal_tasks, dependencies, outkey):


### PR DESCRIPTION
This is using the `Task.fuse` (see https://github.com/dask/dask/pull/11509) method for the Fused task. In theory this should've reduced complexity quite a bit but I encountered problems since the subgraphs are including dead nodes, i.e. there are expressions in `_expr` that are no longer reachable if we walk the tasks. The `Task.fuse` raises in such a case since it requires a subgraph that is uniquely reducing to a single task (I put that condition in to catch stuff like this).

Adding an explicit culling step in advance fixes this so everything is OK. However, where is this redundant node coming from and can we get rid of this??

cc @phofl 