### PR TITLE
Introduce more caching when walking the expression

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -3053,7 +3053,7 @@ def optimize_until(expr: Expr, stage: core.OptimizerStage) -> Expr:
         return expr
 
     # Manipulate Expression to make it more efficient
-    expr = expr.rewrite(kind="tune")
+    expr = expr.rewrite(kind="tune", rewritten={})
     if stage == "tuned-logical":
         return expr
 


### PR DESCRIPTION
This would have brought acceptable performance for #1164. Users can still construct expressions that are very expensive to traverse, so this still makes sense