### PR TITLE
Fix inifinite loop

### DIFF
--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -507,8 +507,6 @@ class Expr:
             if key in _parameters:
                 idx = _parameters.index(key)
                 return self.operands[idx]
-            if is_dataframe_like(self._meta) and key in self._meta.columns:
-                return self[key]
 
             link = "https://github.com/dask-contrib/dask-expr/blob/main/README.md#api-coverage"
             raise AttributeError(


### PR DESCRIPTION
In case of absent `mode` paramater in the custom fsspec file system implementation removed rows caused infinite loop, as mentioned in comments several rows above