### PR TITLE
Remove ``from_dask_dataframe``

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -5020,23 +5020,6 @@ def from_dict(
     )
 
 
-def from_dask_dataframe(*args, **kwargs) -> FrameBase:
-    """Create a dask-expr collection from a legacy dask-dataframe collection
-
-    WARNING: This API is deprecated. Please use `from_legacy_dataframe`.
-
-    Parameters
-    ----------
-    optimize
-        Whether to optimize the graph before conversion.
-    """
-    warnings.warn(
-        "`from_dask_dataframe` is deprecated, please use `from_legacy_dataframe`.",
-        FutureWarning,
-    )
-    return from_legacy_dataframe(*args, **kwargs)
-
-
 def from_legacy_dataframe(ddf: _Frame, optimize: bool = True) -> FrameBase:
     """Create a dask-expr collection from a legacy dask-dataframe collection
 

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -14,7 +14,6 @@ from dask_expr import (
     DataFrame,
     from_array,
     from_dask_array,
-    from_dask_dataframe,
     from_dict,
     from_legacy_dataframe,
     from_map,
@@ -234,11 +233,6 @@ def test_from_legacy_dataframe(optimize):
     df = from_legacy_dataframe(ddf, optimize=optimize)
     assert isinstance(df.expr, Expr)
     assert_eq(df, ddf)
-
-    # Check deprecated API
-    with pytest.warns(FutureWarning, match="deprecated"):
-        df2 = from_dask_dataframe(ddf, optimize=optimize)
-        assert_eq(df, df2)
 
 
 @pytest.mark.parametrize("optimize", [True, False])


### PR DESCRIPTION
this has been deprecated since the release, so just rip it out now to make mental load a bit easier (from_legacy_dataframe still exists)