### PR TITLE
Propagate group_keys in DataFrameGroupBy

### DIFF
--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -1621,6 +1621,7 @@ class GroupBy:
             return SeriesGroupBy(
                 self.obj,
                 by=self.by,
+                group_keys=self.group_keys,
                 slice=key,
                 sort=self.sort,
                 dropna=self.dropna,
@@ -2194,6 +2195,7 @@ class SeriesGroupBy(GroupBy):
         self,
         obj,
         by,
+        group_keys=True,
         sort=None,
         observed=None,
         dropna=None,
@@ -2218,7 +2220,13 @@ class SeriesGroupBy(GroupBy):
                 obj._meta.groupby(by, **_as_dict("observed", observed))
 
         super().__init__(
-            obj, by=by, slice=slice, observed=observed, dropna=dropna, sort=sort
+            obj,
+            by=by,
+            group_keys=group_keys,
+            slice=slice,
+            observed=observed,
+            dropna=dropna,
+            sort=sort,
         )
 
     @derived_from(pd.core.groupby.SeriesGroupBy)

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -1048,3 +1048,16 @@ def test_groupby_index_modified_divisions():
         df.groupby(df.index.dt.date).count(),
         pdf.groupby(pdf.index.date).count(),
     )
+
+
+def test_groupby_getitem_apply_group_keys():
+    pdf = pd.DataFrame(
+        {
+            "A": [0, 1] * 4,
+            "B": [1] * 8,
+        }
+    )
+    df = from_pandas(pdf, npartitions=4)
+    result = df.groupby("A", group_keys=False).B.apply(lambda x: x, meta=("B", int))
+    expected = pdf.groupby("A", group_keys=False).B.apply(lambda x: x)
+    assert_eq(result, expected)


### PR DESCRIPTION
This ensures that selecting a series from a DataFrameGroupBy propagates group_keys correctly. Previously, this was lost since `DataFrameGroupBy.__getitem__` didn't pass it through when creating the SeriesGroupBy.